### PR TITLE
Upstream update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   print(crypto.password.verify("pass", pass_hash))
   ```
 
-- Updated backend for print formating.
-- Updated Internal package.
+### Changed
+- Partial backend code for print formating.
+- Internal package.
 
 ## `0.0.5` - August 29, 2024
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+- Added `@zcore/crypto` built-in library. [More Info](https://scythe-technology.github.io/zune-docs/docs/api/crypto)
+
+  Example:
+  ```luau
+  local crypto = require("@zcore/crypto")
+  local hash = crypto.hash.sha2.sha256("Hello World!")
+  local hmac = crypto.hmac.sha2.sha256("Hello World!", "private key")
+  local pass_hash = crypto.password.hash("pass")
+
+  print(crypto.password.verify("pass", pass_hash))
+  ```
+
+- Updated backend for print formating.
+- Updated Internal package.
+
 ## `0.0.5` - August 29, 2024
 
 ### Changed

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = "Zune",
-    .version = "0.0.5",
+    .version = "0.1.0",
     .minimum_zig_version = "0.13.0",
     .dependencies = .{
         .json = .{
@@ -16,8 +16,8 @@
             .hash = "1220d6bbca59a59f16bda33b69e140d90bad313d11c07c0e2ab16076c59355845112",
         },
         .luau = .{
-            .url = "https://codeload.github.com/SnorlaxAssist/zig-luau/tar.gz/352df99f32034fa8a65162ad35b9a9a9f27ae576",
-            .hash = "1220b2b0d91602470fd2e17d1fd6c881475d3bdfe8287d72409b3f9e4d81328d1d0b",
+            .url = "https://codeload.github.com/SnorlaxAssist/zig-luau/tar.gz/fc385b1db1f68de1a5e242ed2fee77add1e47dd9",
+            .hash = "1220cd16498a29dadde7dee091b703904963b2781997dacfd34f08dbe62177473637",
         },
     },
     .paths = .{

--- a/src/commands/setup.zig
+++ b/src/commands/setup.zig
@@ -18,6 +18,7 @@ const typedefs = &[_]typedef{
     typedef{ .name = "core/luau", .content = @embedFile("../types/core/luau.luau.gz") },
     typedef{ .name = "core/serde", .content = @embedFile("../types/core/serde.luau.gz") },
     typedef{ .name = "core/stdio", .content = @embedFile("../types/core/stdio.luau.gz") },
+    typedef{ .name = "core/crypto", .content = @embedFile("../types/core/crypto.luau.gz") },
     typedef{ .name = "core/process", .content = @embedFile("../types/core/process.luau.gz") },
     typedef{ .name = "core/testing", .content = @embedFile("../types/core/testing.luau.gz") },
 };

--- a/src/core/standard/crypto/common.zig
+++ b/src/core/standard/crypto/common.zig
@@ -1,0 +1,42 @@
+const std = @import("std");
+const luau = @import("luau");
+
+const Luau = luau.Luau;
+
+pub fn lua_genHashFn(comptime hash_algorithm: anytype) luau.ZigFn {
+    return struct {
+        fn hash(L: *Luau) i32 {
+            const data = L.checkString(1);
+
+            var buf: [hash_algorithm.digest_length]u8 = undefined;
+
+            hash_algorithm.hash(data, &buf, .{});
+
+            const hex = std.fmt.bytesToHex(&buf, .lower);
+
+            L.pushLString(&hex);
+
+            return 1;
+        }
+    }.hash;
+}
+
+pub fn lua_genHmacFn(comptime hash_algorithm: anytype) luau.ZigFn {
+    const hmac_algorithm = std.crypto.auth.hmac.Hmac(hash_algorithm);
+    return struct {
+        fn hash(L: *Luau) i32 {
+            const data = L.checkString(1);
+            const key = L.checkString(2);
+
+            var buf: [hmac_algorithm.key_length]u8 = undefined;
+
+            hmac_algorithm.create(&buf, data, key);
+
+            const hex = std.fmt.bytesToHex(&buf, .lower);
+
+            L.pushLString(&hex);
+
+            return 1;
+        }
+    }.hash;
+}

--- a/src/core/standard/crypto/lib.zig
+++ b/src/core/standard/crypto/lib.zig
@@ -1,0 +1,151 @@
+const std = @import("std");
+const luau = @import("luau");
+
+const Engine = @import("../../runtime/engine.zig");
+const Scheduler = @import("../../runtime/scheduler.zig");
+
+const common = @import("common.zig");
+
+const Luau = luau.Luau;
+
+const hash = std.crypto.hash;
+
+const password = @import("password.zig");
+
+pub fn loadLib(L: *Luau) void {
+    L.newTable();
+
+    { // hash
+        L.newTable();
+
+        // Md5
+        L.setFieldFn(-1, "md5", common.lua_genHashFn(hash.Md5));
+        // Sha1
+        L.setFieldFn(-1, "sha1", common.lua_genHashFn(hash.Sha1));
+        // Blake3
+        L.setFieldFn(-1, "blake3", common.lua_genHashFn(hash.Blake3));
+
+        { // Sha2
+            L.newTable();
+
+            L.setFieldFn(-1, "sha224", common.lua_genHashFn(hash.sha2.Sha224));
+            L.setFieldFn(-1, "sha256", common.lua_genHashFn(hash.sha2.Sha256));
+            L.setFieldFn(-1, "sha384", common.lua_genHashFn(hash.sha2.Sha384));
+            L.setFieldFn(-1, "sha512", common.lua_genHashFn(hash.sha2.Sha512));
+
+            L.setFieldAhead(-1, "sha2");
+        }
+
+        { // Sha3
+            L.newTable();
+
+            L.setFieldFn(-1, "sha3_224", common.lua_genHashFn(hash.sha3.Sha3_224));
+            L.setFieldFn(-1, "sha3_256", common.lua_genHashFn(hash.sha3.Sha3_256));
+            L.setFieldFn(-1, "sha3_384", common.lua_genHashFn(hash.sha3.Sha3_384));
+            L.setFieldFn(-1, "sha3_512", common.lua_genHashFn(hash.sha3.Sha3_512));
+
+            L.setFieldAhead(-1, "sha3");
+        }
+
+        { // Blake2
+            L.newTable();
+
+            L.setFieldFn(-1, "b128", common.lua_genHashFn(hash.blake2.Blake2b128));
+            L.setFieldFn(-1, "b160", common.lua_genHashFn(hash.blake2.Blake2b160));
+            L.setFieldFn(-1, "b256", common.lua_genHashFn(hash.blake2.Blake2b256));
+            L.setFieldFn(-1, "b384", common.lua_genHashFn(hash.blake2.Blake2b384));
+            L.setFieldFn(-1, "b512", common.lua_genHashFn(hash.blake2.Blake2b512));
+
+            L.setFieldFn(-1, "s128", common.lua_genHashFn(hash.blake2.Blake2s128));
+            L.setFieldFn(-1, "s160", common.lua_genHashFn(hash.blake2.Blake2s160));
+            L.setFieldFn(-1, "s224", common.lua_genHashFn(hash.blake2.Blake2s224));
+            L.setFieldFn(-1, "s256", common.lua_genHashFn(hash.blake2.Blake2s256));
+
+            L.setFieldAhead(-1, "blake2");
+        }
+
+        L.setFieldAhead(-1, "hash");
+    }
+
+    { // hmac
+        L.newTable();
+
+        // Md5
+        L.setFieldFn(-1, "md5", common.lua_genHmacFn(hash.Md5));
+        // Sha1
+        L.setFieldFn(-1, "sha1", common.lua_genHmacFn(hash.Sha1));
+        // Blake3
+        L.setFieldFn(-1, "blake3", common.lua_genHmacFn(hash.Blake3));
+
+        { // Sha2
+            L.newTable();
+
+            L.setFieldFn(-1, "sha224", common.lua_genHmacFn(hash.sha2.Sha224));
+            L.setFieldFn(-1, "sha256", common.lua_genHmacFn(hash.sha2.Sha256));
+            L.setFieldFn(-1, "sha384", common.lua_genHmacFn(hash.sha2.Sha384));
+            L.setFieldFn(-1, "sha512", common.lua_genHmacFn(hash.sha2.Sha512));
+
+            L.setFieldAhead(-1, "sha2");
+        }
+
+        { // Sha3
+            L.newTable();
+
+            L.setFieldFn(-1, "sha3_224", common.lua_genHmacFn(hash.sha3.Sha3_224));
+            L.setFieldFn(-1, "sha3_256", common.lua_genHmacFn(hash.sha3.Sha3_256));
+            L.setFieldFn(-1, "sha3_384", common.lua_genHmacFn(hash.sha3.Sha3_384));
+            L.setFieldFn(-1, "sha3_512", common.lua_genHmacFn(hash.sha3.Sha3_512));
+
+            L.setFieldAhead(-1, "sha3");
+        }
+
+        { // Blake2
+            L.newTable();
+
+            L.setFieldFn(-1, "b128", common.lua_genHmacFn(hash.blake2.Blake2b128));
+            L.setFieldFn(-1, "b160", common.lua_genHmacFn(hash.blake2.Blake2b160));
+            L.setFieldFn(-1, "b256", common.lua_genHmacFn(hash.blake2.Blake2b256));
+            L.setFieldFn(-1, "b384", common.lua_genHmacFn(hash.blake2.Blake2b384));
+            L.setFieldFn(-1, "b512", common.lua_genHmacFn(hash.blake2.Blake2b512));
+
+            L.setFieldFn(-1, "s128", common.lua_genHmacFn(hash.blake2.Blake2s128));
+            L.setFieldFn(-1, "s160", common.lua_genHmacFn(hash.blake2.Blake2s160));
+            L.setFieldFn(-1, "s224", common.lua_genHmacFn(hash.blake2.Blake2s224));
+            L.setFieldFn(-1, "s256", common.lua_genHmacFn(hash.blake2.Blake2s256));
+
+            L.setFieldAhead(-1, "blake2");
+        }
+
+        L.setFieldAhead(-1, "hmac");
+    }
+
+    { // password
+        L.newTable();
+
+        L.setFieldFn(-1, "hash", password.lua_hash);
+        L.setFieldFn(-1, "verify", password.lua_verify);
+
+        L.setFieldAhead(-1, "password");
+    }
+
+    _ = L.findTable(luau.REGISTRYINDEX, "_MODULES", 1);
+    if (L.getField(-1, "@zcore/crypto") != .table) {
+        L.pop(1);
+        L.pushValue(-2);
+        L.setField(-2, "@zcore/crypto");
+    } else L.pop(1);
+    L.pop(2);
+}
+
+test {
+    std.testing.refAllDecls(@This());
+}
+
+test "Crypto" {
+    const TestRunner = @import("../../utils/testrunner.zig");
+
+    const testResult = try TestRunner.runTest(std.testing.allocator, @import("zune-test-files").@"crypto.test", &.{}, true);
+
+    try std.testing.expect(testResult.failed == 0);
+    try std.testing.expect(testResult.total > 0);
+}

--- a/src/core/standard/crypto/password.zig
+++ b/src/core/standard/crypto/password.zig
@@ -1,0 +1,120 @@
+const std = @import("std");
+const luau = @import("luau");
+
+const common = @import("common.zig");
+
+const Luau = luau.Luau;
+
+const argon2 = std.crypto.pwhash.argon2;
+const bcrypt = std.crypto.pwhash.bcrypt;
+
+const Algorithm = enum {
+    argon2d,
+    argon2i,
+    argon2id,
+    bcrypt,
+};
+
+const AlgorithmUnion = union(Algorithm) {
+    argon2d: argon2.Mode,
+    argon2i: argon2.Mode,
+    argon2id: argon2.Mode,
+    bcrypt: void,
+};
+
+const DEFAULT_ALGO: AlgorithmUnion = .{ .argon2d = .argon2d };
+const AlgorithmMap = std.StaticStringMap(AlgorithmUnion).initComptime(.{
+    .{ "argon2d", DEFAULT_ALGO },
+    .{ "argon2i", .{ .argon2i = .argon2i } },
+    .{ "argon2id", .{ .argon2id = .argon2id } },
+    .{ "bcrypt", .{ .bcrypt = @as(void, undefined) } },
+});
+
+pub fn lua_hash(L: *Luau) !i32 {
+    const allocator = L.allocator();
+    const password = L.checkString(1);
+
+    var algorithm = DEFAULT_ALGO;
+    var cost: u32 = 65536;
+    var cost2: u32 = 2;
+
+    switch (try L.typeOfObjConsumed(2)) {
+        .table => {
+            switch (try L.getFieldObjConsumed(2, "algorithm")) {
+                .string => |s| algorithm = AlgorithmMap.get(s) orelse L.raiseErrorStr("Invalid Algorithm", .{}),
+                .none, .nil => {},
+                else => return L.raiseErrorStr("Invalid `algorithm` (String expected)", .{}),
+            }
+            switch (algorithm) {
+                .argon2d, .argon2i, .argon2id => {
+                    switch (try L.getFieldObjConsumed(2, "memoryCost")) {
+                        .number => |n| cost = @intFromFloat(n),
+                        .none, .nil => {},
+                        else => L.raiseErrorStr("Invalid 'memoryCost' (Number expected)", .{}),
+                    }
+                    switch (try L.getFieldObjConsumed(2, "timeCost")) {
+                        .number => |n| cost2 = @intFromFloat(n),
+                        .none, .nil => {},
+                        else => L.raiseErrorStr("Invalid 'timeCost' (Number expected)", .{}),
+                    }
+                },
+                .bcrypt => {
+                    cost = 4;
+                    switch (try L.getFieldObjConsumed(2, "cost")) {
+                        .number => |n| {
+                            cost = @intFromFloat(n);
+                            if (cost < 4 or cost > 31) L.raiseErrorStr("Invalid 'cost' (Must be between 4 to 31)", .{});
+                        },
+                        .none, .nil => {},
+                        else => L.raiseErrorStr("Invalid 'cost' (Number expected)", .{}),
+                    }
+                },
+            }
+        },
+        .none, .nil => {},
+        else => L.checkType(2, .table),
+    }
+
+    var buf: [128]u8 = undefined;
+    switch (algorithm) {
+        .argon2d, .argon2i, .argon2id => |mode| {
+            const hash = try argon2.strHash(password, .{
+                .allocator = allocator,
+                .params = .{ .m = cost, .t = cost2, .p = 1 },
+                .mode = mode,
+            }, &buf);
+            L.pushLString(hash);
+        },
+        .bcrypt => {
+            const hash = try bcrypt.strHash(password, .{
+                .allocator = allocator,
+                .params = .{ .rounds_log = @intCast(cost) },
+                .encoding = .phc,
+            }, &buf);
+            L.pushLString(hash);
+        },
+    }
+    return 1;
+}
+
+const TAG_BCRYPT: u32 = @bitCast([4]u8{ '$', 'b', 'c', 'r' });
+
+pub fn lua_verify(L: *Luau) i32 {
+    const allocator = L.allocator();
+    const password = L.checkString(1);
+    const hash = L.checkString(2);
+
+    if (hash.len < 8) L.raiseErrorStr("InvalidHash (Must be PHC encoded)", .{});
+
+    if (@as(u32, @bitCast(hash[0..4].*)) == TAG_BCRYPT) L.pushBoolean(if (bcrypt.strVerify(
+        hash,
+        password,
+        .{ .allocator = allocator },
+    )) true else |_| false) else L.pushBoolean(if (argon2.strVerify(
+        hash,
+        password,
+        .{ .allocator = allocator },
+    )) true else |_| false);
+
+    return 1;
+}

--- a/src/core/standard/lib.zig
+++ b/src/core/standard/lib.zig
@@ -4,6 +4,7 @@ pub const luau = @import("luau.zig");
 pub const net = @import("net/lib.zig");
 pub const stdio = @import("stdio.zig");
 pub const serde = @import("serde/lib.zig");
+pub const crypto = @import("crypto/lib.zig");
 pub const process = @import("process.zig");
 pub const testing = @import("testing.zig");
 

--- a/src/types/core/crypto.luau
+++ b/src/types/core/crypto.luau
@@ -1,0 +1,75 @@
+type HashFn = (str: string) -> string;
+type HmacFn = (str: string, key: string) -> string;
+
+type HashAlgorithms<F> = {
+    sha1: F,
+    md5: F,
+    blake3: F,
+    sha2: {
+        sha224: F,
+        sha256: F,
+        sha384: F,
+        sha512: F,
+    },
+    sha3: {
+        sha3_224: F,
+        sha3_256: F,
+        sha3_384: F,
+        sha3_512: F,
+    },
+    blake2: {
+        b128: F,
+        b160: F,
+        b256: F,
+        b512: F,
+        s128: F,
+        s160: F,
+        s224: F,
+        s256: F,
+    },
+};
+
+type BcryptPasswordOptions = {
+    --- Default: "argon2d"
+    algorithm: "bcrypt"?,
+    --[[
+        Default: 4
+        
+        Only between 4 and 31
+    ]]
+    cost: number?,
+};
+
+type Argon2PasswordOptions = {
+    --- Default: "argon2d"
+    algorithm: ("argon2d" | "argon2i" | "argon2id")?,
+    --- Default: 2
+    timeCost: number?,
+    --- Default: 65536
+    memoryCost: number?,
+};
+
+type PasswordOptions = BcryptPasswordOptions | Argon2PasswordOptions;
+
+
+local crypto = {}
+
+--[[
+    Hash functions
+]]
+crypto.hash = (nil :: any) :: HashAlgorithms<HashFn>
+
+--[[
+    HMAC functions
+]]
+crypto.hmac = (nil :: any) :: HashAlgorithms<HmacFn>;
+
+--[[
+    Password hashing function
+]]
+crypto.password = (nil :: any) :: {
+    hash: (password: string, options: PasswordOptions?) -> string,
+    verify: (password: string, hash: string) -> boolean,
+};
+
+return crypto;

--- a/src/zune.zig
+++ b/src/zune.zig
@@ -36,6 +36,7 @@ pub fn openZune(L: *luau.Luau, args: []const []const u8, mode: RunMode) !void {
     corelib.luau.loadLib(L);
     corelib.serde.loadLib(L);
     corelib.stdio.loadLib(L);
+    corelib.crypto.loadLib(L);
     try corelib.net.loadLib(L);
     try corelib.process.loadLib(L, args);
 

--- a/test/files.zig
+++ b/test/files.zig
@@ -18,5 +18,6 @@ pub const @"luau.test" = newFile("standard/luau.test.luau");
 pub const @"task.test" = newFile("standard/task.test.luau");
 pub const @"stdio.test" = newFile("standard/stdio.test.luau");
 pub const @"serde.test" = newFile("standard/serde/init.test.luau");
+pub const @"crypto.test" = newFile("standard/crypto/init.test.luau");
 pub const @"process.test" = newFile("standard/process.test.luau");
 pub const @"testing.test" = newFile("standard/testing.test.luau");

--- a/test/standard/crypto/hash.test.luau
+++ b/test/standard/crypto/hash.test.luau
@@ -1,0 +1,104 @@
+--!strict
+local crypto = require("@zcore/crypto");
+local testing = require("@zcore/testing");
+
+local describe = testing.describe;
+local expect = testing.expect;
+local test = testing.test;
+
+describe("Hash", function()
+    test("Sha1", function()
+        expect(crypto.hash.sha1("test")).toBe("a94a8fe5ccb19ba61c4c0873d391e987982fbbd3");
+        expect(crypto.hash.sha1("zune+luau")).toBe("e47cdb8177c155af61402e8b190eaf9fcda19be3");
+    end)
+
+    test("Md5", function()
+        expect(crypto.hash.md5("test")).toBe("098f6bcd4621d373cade4e832627b4f6");
+        expect(crypto.hash.md5("zune+luau")).toBe("e478afbf1154b4c52fdc83f01ab9a177");
+    end)
+
+    test("Blake3", function()
+        expect(crypto.hash.blake3("test")).toBe("4878ca0425c739fa427f7eda20fe845f6b2e46ba5fe2a14df5b1e32f50603215");
+        expect(crypto.hash.blake3("zune+luau")).toBe("f1126dcda96d8cd8dde7029db26ff88bbb5cecffe40e58518489339fc8dc256d");
+    end)
+
+    describe("Sha2", function()
+        test("sha224", function()
+            expect(crypto.hash.sha2.sha224("test")).toBe("90a3ed9e32b2aaf4c61c410eb925426119e1a9dc53d4286ade99a809");
+            expect(crypto.hash.sha2.sha224("zune+luau")).toBe("c314498b655562271ecc28b6e92075a8b22e7f38f5b2449506c9f354");
+        end)
+        test("sha256", function()
+            expect(crypto.hash.sha2.sha256("test")).toBe("9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08");
+            expect(crypto.hash.sha2.sha256("zune+luau")).toBe("d8e2b7516dea78ab5e68429e26a48b33e4f1a84955d7fe3f0a261c3549d3c41a");
+        end)
+        test("sha384", function()
+            expect(crypto.hash.sha2.sha384("test")).toBe("768412320f7b0aa5812fce428dc4706b3cae50e02a64caa16a782249bfe8efc4b7ef1ccb126255d196047dfedf17a0a9");
+            expect(crypto.hash.sha2.sha384("zune+luau")).toBe("c8d3ba84d8fbe5025d9913cc015dc69c635af4d9b946f0bab1f9814f05a1372d84e6b5179824e4ad8e1a1022ec0e6bfa");
+        end)
+        test("sha512", function()
+            expect(crypto.hash.sha2.sha512("test")).toBe("ee26b0dd4af7e749aa1a8ee3c10ae9923f618980772e473f8819a5d4940e0db27ac185f8a0e1d5f84f88bc887fd67b143732c304cc5fa9ad8e6f57f50028a8ff");
+            expect(crypto.hash.sha2.sha512("zune+luau")).toBe("232dcb06ce1e2001400f409d51acda3d8e8361e42505b20aea41a60432b1699173de3d8784301ffdba5019e1ad2b91cd1acfb93c4e1bf5814ce8da6be600b928");
+        end)
+    end)
+
+    describe("Sha3", function()
+        test("sha3_224", function()
+            expect(crypto.hash.sha3.sha3_224("test")).toBe("3797bf0afbbfca4a7bbba7602a2b552746876517a7f9b7ce2db0ae7b");
+            expect(crypto.hash.sha3.sha3_224("zune+luau")).toBe("bf4a366cffa2dc443d7c369fdc2c691da46e1d592d23450217e6acdb");
+        end)
+        test("sha3_256", function()
+            expect(crypto.hash.sha3.sha3_256("test")).toBe("36f028580bb02cc8272a9a020f4200e346e276ae664e45ee80745574e2f5ab80");
+            expect(crypto.hash.sha3.sha3_256("zune+luau")).toBe("7cff4669db67cb0feadb81327cdbfe15d585ca00b778ebba82b16585c61517f5");
+        end)
+        test("sha3_384", function()
+            expect(crypto.hash.sha3.sha3_384("test")).toBe("e516dabb23b6e30026863543282780a3ae0dccf05551cf0295178d7ff0f1b41eecb9db3ff219007c4e097260d58621bd");
+            expect(crypto.hash.sha3.sha3_384("zune+luau")).toBe("d278ebf323e253cf0dfbb7b404dfa4534ba84c973ca9f514545e3c2353659e1cde817360d7e5dce11a11b6f0adcc2dfd");
+        end)
+        test("sha3_512", function()
+            expect(crypto.hash.sha3.sha3_512("test")).toBe("9ece086e9bac491fac5c1d1046ca11d737b92a2b2ebd93f005d7b710110c0a678288166e7fbe796883a4f2e9b3ca9f484f521d0ce464345cc1aec96779149c14");
+            expect(crypto.hash.sha3.sha3_512("zune+luau")).toBe("884cddf86715170e6538f518de9eca945005c1f09237d2cceba90bb120cfac59fedfed37b604bde3b9a509a545328dec7d73c81acfd8c0768b5c02e86042db96");
+        end)
+    end)
+
+    describe("Blake2", function()
+        test("b128", function()
+            expect(crypto.hash.blake2.b128("test")).toBe("44a8995dd50b6657a037a7839304535b");
+            expect(crypto.hash.blake2.b128("zune+luau")).toBe("c97ab5fc7cb9b15db8f5471514da1fdb");
+        end)
+        test("b160", function()
+            expect(crypto.hash.blake2.b160("test")).toBe("a34fc3b6d2cce8beb3216c2bbb5e55739e8121ed");
+            expect(crypto.hash.blake2.b160("zune+luau")).toBe("506805b2c79624b73aea9e82cd57703953b0e042");
+        end)
+        test("b256", function()
+            expect(crypto.hash.blake2.b256("test")).toBe("928b20366943e2afd11ebc0eae2e53a93bf177a4fcf35bcc64d503704e65e202");
+            expect(crypto.hash.blake2.b256("zune+luau")).toBe("9ffe181c04b44ca97758eb3f788a3c90d7dc9aac9e6e2588906bc1ae40ac7c00");
+        end)
+        test("b384", function()
+            expect(crypto.hash.blake2.b384("test")).toBe("8a84b8666c8fcfb69f2ec41f578d7c85fbdb504ea6510fb05b50fcbf7ed8153c77943bc2da73abb136834e1a0d4f22cb");
+            expect(crypto.hash.blake2.b384("zune+luau")).toBe("68f3f00f46c5f041ec37c04214a3c53b3bfdfe431ba00f99b48ffff1b28f9b774cca510de345b96e5d3daafeaa3ed593");
+        end)
+        test("b512", function()
+            expect(crypto.hash.blake2.b512("test")).toBe("a71079d42853dea26e453004338670a53814b78137ffbed07603a41d76a483aa9bc33b582f77d30a65e6f29a896c0411f38312e1d66e0bf16386c86a89bea572");
+            expect(crypto.hash.blake2.b512("zune+luau")).toBe("b67df6024a3c4aa3f1d570046a6df2813a8e632b378c08e5e3a559c6908445ff4bcf97de1176157a292418eb1708788fb8a8f1db1cf27c427e46311dc08ad32d");
+        end)
+
+        test("s128", function()
+            expect(crypto.hash.blake2.s128("test")).toBe("e9ddd9926b9dcb382e09be39ba403d2c");
+            expect(crypto.hash.blake2.s128("zune+luau")).toBe("fc48cc89b0a33c36e3484aa4c5956e27");
+        end)
+        test("s160", function()
+            expect(crypto.hash.blake2.s160("test")).toBe("d6197dabec2bd6f4ff303b8e519e8f15d42a453d");
+            expect(crypto.hash.blake2.s160("zune+luau")).toBe("124cb016c7c70034aeedfaee5451c42bf5f8af32");
+        end)
+        test("s224", function()
+            expect(crypto.hash.blake2.s224("test")).toBe("3a844209334631559b69dbea0fc9a71f580909c075a07c5078aabb9b");
+            expect(crypto.hash.blake2.s224("zune+luau")).toBe("5eb74952f0923c8d9a9195a888b0773581cdbc511d2df63b5bec0385");
+        end)
+        test("s256", function()
+            expect(crypto.hash.blake2.s256("test")).toBe("f308fc02ce9172ad02a7d75800ecfc027109bc67987ea32aba9b8dcc7b10150e");
+            expect(crypto.hash.blake2.s256("zune+luau")).toBe("7c70ca6e74e51566f3610af111d3bd3b47a91984902e6db5261fccb63e6d2470");
+        end)
+    end)
+end)
+
+return nil;

--- a/test/standard/crypto/hmac.test.luau
+++ b/test/standard/crypto/hmac.test.luau
@@ -1,0 +1,104 @@
+--!strict
+local crypto = require("@zcore/crypto");
+local testing = require("@zcore/testing");
+
+local describe = testing.describe;
+local expect = testing.expect;
+local test = testing.test;
+
+describe("Hmac", function()
+    test("Sha1", function()
+        expect(crypto.hmac.sha1("test", "some-key")).toBe("663a5152a12a3431459c0f284fe9ddff8d8e0153");
+        expect(crypto.hmac.sha1("zune+luau", "runtime")).toBe("b11d13f56ca5f82ea69c1ed1a3581f502ea3dca0");
+    end)
+
+    test("Md5", function()
+        expect(crypto.hmac.md5("test", "some-key")).toBe("257e3a4df0ef0da897d69c7c182fb8e9");
+        expect(crypto.hmac.md5("zune+luau", "runtime")).toBe("607657d1110114b4083cfc796b4ba4b1");
+    end)
+
+    test("Blake3", function()
+        expect(crypto.hmac.blake3("test", "some-key")).toBe("395b0ebc7db29f0fce312ae2f3f235feb74303daac3cc5edd828f784fce6346e");
+        expect(crypto.hmac.blake3("zune+luau", "runtime")).toBe("226148d571df6c1850bae14e37045a5b36cdf8352f0fbbbdeaeb95d74e1641ad");
+    end)
+
+    describe("Sha2", function()
+        test("sha224", function()
+            expect(crypto.hmac.sha2.sha224("test", "some-key")).toBe("54fa1f243580d0d9bdbcd5243d6b40b6540f99d42663ea8d22cfe5ee");
+            expect(crypto.hmac.sha2.sha224("zune+luau", "runtime")).toBe("1cca3905ba8de9d9dfcded575156aaee816147e411787f633334ef4c");
+        end)
+        test("sha256", function()
+            expect(crypto.hmac.sha2.sha256("test", "some-key")).toBe("08c22ecc31c998cece3771f92dcbb623fb71998ce067f406f51a45fc4802ea7a");
+            expect(crypto.hmac.sha2.sha256("zune+luau", "runtime")).toBe("68f6b45c033c963884fdfea51530e57092a7722b7235d14724e7617e91b55e04");
+        end)
+        test("sha384", function()
+            expect(crypto.hmac.sha2.sha384("test", "some-key")).toBe("a37be4ffdddbf9bbf20ccaf05a33207e33964fd228280db7734827cc67c83e0e12f80f68c08680cce0024621e7b7b69f");
+            expect(crypto.hmac.sha2.sha384("zune+luau", "runtime")).toBe("b21d024b2e243187b308e9cd7b603b50732184b144dce56a026286c4adcef9c73449eb64144d5400028a17c4e5ce91c7");
+        end)
+        test("sha512", function()
+            expect(crypto.hmac.sha2.sha512("test", "some-key")).toBe("5d150ffa09b582906efd6e68556513a221444c71f814234e08d2b23e8c94b99ace54c4394b93aa4ffcb9fa09763f0f6ad83d70219d0c859d37514e3cd06010b6");
+            expect(crypto.hmac.sha2.sha512("zune+luau", "runtime")).toBe("7dca7dc138842b8f27e126bfad7d7c36794cd3e03f8dc8991e13fe72f1d5d6b8b1ce0bca1c4e3a6ff2040417f20b013883b4d3515fabe5d19c3e5662249095c0");
+        end)
+    end)
+
+    describe("Sha3", function()
+        test("sha3_224", function()
+            expect(crypto.hmac.sha3.sha3_224("test", "some-key")).toBe("4a4f2229c72784ead0a97fee4bac9b3d41be32f79f6207d3dd91be9b");
+            expect(crypto.hmac.sha3.sha3_224("zune+luau", "runtime")).toBe("8a0169afad4e6adae7a59f98172b4a002d1d69f3fc6a3665155f2773");
+        end)
+        test("sha3_256", function()
+            expect(crypto.hmac.sha3.sha3_256("test", "some-key")).toBe("b5fd647e9d8c8b425322fafee4de2b7f46119d6082bdee5d6ca77ac5cf1ce059");
+            expect(crypto.hmac.sha3.sha3_256("zune+luau", "runtime")).toBe("ac8d782eb429817e39244cc7e3bc23cf9ae5e8279c985957ae8fd7b2b8e29665");
+        end)
+        test("sha3_384", function()
+            expect(crypto.hmac.sha3.sha3_384("test", "some-key")).toBe("e2f092be4fd489d994d85b6d9c0b7ba6891cdaad96b5cfa1827aeea073334266dcc07e666081d1ddbd66cdcadbee1f7e");
+            expect(crypto.hmac.sha3.sha3_384("zune+luau", "runtime")).toBe("18f0289ae1405080fe5ab2962212daa46180584044bee8ef95264ee300696ae784bc7cd5a387d26a72d3ec9f36acf677");
+        end)
+        test("sha3_512", function()
+            expect(crypto.hmac.sha3.sha3_512("test", "some-key")).toBe("7f3c9c71b86f1279395d4989b497784583560558e50f8a31348ab6c81a2ac188f66ce16fdcdfc67886817d1eb795327353edfeeca913fc559af1126754f2c125");
+            expect(crypto.hmac.sha3.sha3_512("zune+luau", "runtime")).toBe("e9c4a0caf18f7ddcea1ac1b50eb7d1d1144d8eecb4bcd94d4d5257c7ace6055d343184f92cb2a381b12d15db61f124af965e4b57323da1414bbad6c244ed8c9f");
+        end)
+    end)
+
+    describe("Blake2", function()
+        test("b128", function()
+            expect(crypto.hmac.blake2.b128("test", "some-key")).toBe("438c66c9aae2e28baa7f99b4ba7f8cc6");
+            expect(crypto.hmac.blake2.b128("zune+luau", "runtime")).toBe("4abb551cf85ca8cf4dc0516abcce8ef1");
+        end)
+        test("b160", function()
+            expect(crypto.hmac.blake2.b160("test", "some-key")).toBe("dd9e1caacf9f29879381906eb2e5bcf3c64b860c");
+            expect(crypto.hmac.blake2.b160("zune+luau", "runtime")).toBe("755475da5965133dee884014d11c875c58d720e1");
+        end)
+        test("b256", function()
+            expect(crypto.hmac.blake2.b256("test", "some-key")).toBe("bc87fab7982b6d73001e235d599029e2a00dbda92f763e0bda53124bbe3d13e9");
+            expect(crypto.hmac.blake2.b256("zune+luau", "runtime")).toBe("0d760abdc0f6a4a608c720c3b23ba70c65ae14fbc99a9c5c1e4d63c8f3415ac0");
+        end)
+        test("b384", function()
+            expect(crypto.hmac.blake2.b384("test", "some-key")).toBe("345bd3a69008ee336931da61ffbb7179711aafdd8c2b298a95b6f3a1d96b70f19a965319cf79a55ee6436c9c7d30efd8");
+            expect(crypto.hmac.blake2.b384("zune+luau", "runtime")).toBe("39f5ac95daccf12ed5cf9d3593d527e151b47dfac6cd10454c9e65c2db92bbca9db1d990d31681a55e9a66731f6b1f02");
+        end)
+        test("b512", function()
+            expect(crypto.hmac.blake2.b512("test", "some-key")).toBe("f199d0d53e94f114ed8a1115949d283e2895f020a675c2cea0117e715de470110873594654cc6b5d2a60b768d7a11499e1303309240ecbde44e7a916fa39fe01");
+            expect(crypto.hmac.blake2.b512("zune+luau", "runtime")).toBe("a5c06e6a5a76e610e4a985617d7e60d29a709e96203b50e0a141a70c1978937fe1237d21dd65a85cbdb7f6511f06e2ad40a2931559495da5fadc877fbd1643d2");
+        end)
+
+        test("s128", function()
+            expect(crypto.hmac.blake2.s128("test", "some-key")).toBe("b7cecf1a2f2e2e59e2b70e6a296545b7");
+            expect(crypto.hmac.blake2.s128("zune+luau", "runtime")).toBe("eedd3b59d776e6c552a83fe2b180daaf");
+        end)
+        test("s160", function()
+            expect(crypto.hmac.blake2.s160("test", "some-key")).toBe("3c8968ee6a2f75931783551958259a960fb2d790");
+            expect(crypto.hmac.blake2.s160("zune+luau", "runtime")).toBe("b88f93824f9eac02b75133165404dffeae358cae");
+        end)
+        test("s224", function()
+            expect(crypto.hmac.blake2.s224("test", "some-key")).toBe("6aeef170baa920953b7df0dc3613cd79040a256cb99cbb2685c06eac");
+            expect(crypto.hmac.blake2.s224("zune+luau", "runtime")).toBe("ca99a58dc2815bac1f0ebf83c6eef9eb2ca99012256c466251d64768");
+        end)
+        test("s256", function()
+            expect(crypto.hmac.blake2.s256("test", "some-key")).toBe("0dac61f5e3a0d88a6e0b82c22b95a9e6b04c4404dbfb53a76ffff2e091518710");
+            expect(crypto.hmac.blake2.s256("zune+luau", "runtime")).toBe("6b0a921884d662f74ac09802350302b3935307d1c75b004bad6959f18907a79b");
+        end)
+    end)
+end)
+
+return nil;

--- a/test/standard/crypto/init.test.luau
+++ b/test/standard/crypto/init.test.luau
@@ -1,0 +1,5 @@
+--!strict
+
+require("./hash.test");
+require("./hmac.test");
+require("./password.test");

--- a/test/standard/crypto/password.test.luau
+++ b/test/standard/crypto/password.test.luau
@@ -1,0 +1,61 @@
+--!strict
+local crypto = require("@zcore/crypto");
+local testing = require("@zcore/testing");
+
+local describe = testing.describe;
+local expect = testing.expect;
+local test = testing.test;
+
+local function testPassword(password: string, options: any?)
+    local hash = crypto.password.hash(password, options);
+    local hash2 = crypto.password.hash(password, options);
+    test("Hash", function()
+        -- Hashes should be different
+        expect(hash).never.toBe(hash2);
+        if (options) then
+            expect(hash:sub(1, #options.algorithm + 2)).toBe(`${options.algorithm}$`);
+        end
+    end)
+    test("Verification", function()
+        expect(crypto.password.verify(password, hash)).toBe(true);
+        expect(crypto.password.verify(password .. 'other', hash)).toBe(false);
+    end)
+end
+
+describe("Password", function()
+    describe("Default", function()
+        testPassword("zune+luau")
+    end)
+
+    describe("Argon2i", function()
+        testPassword("zune+luau", {algorithm = "argon2i"})
+    end)
+    describe("Argon2id", function()
+        testPassword("zune+luau", {algorithm = "argon2id"})
+    end)
+    describe("Bcrypt", function()
+        testPassword("zune+luau", {algorithm = "bcrypt"})
+    end)
+
+    test("Fail", function()
+        expect(function()
+            crypto.password.hash("blank", {
+                algorithm = "argon2b",
+            })
+        end).toThrow("Invalid Algorithm");
+        expect(function()
+            crypto.password.hash("blank", {
+                algorithm = "argon2d",
+                timeCost = "0",
+            })
+        end).toThrow("Invalid 'timeCost' (Number expected)");
+        expect(function()
+            crypto.password.hash("blank", {
+                algorithm = "bcrypt",
+                cost = "0",
+            })
+        end).toThrow("Invalid 'cost' (Number expected)");
+    end)
+end)
+
+return nil;


### PR DESCRIPTION
### Added
- Added `@zcore/crypto` built-in library. [More Info](https://scythe-technology.github.io/zune-docs/docs/api/crypto)

  Example:
  ```luau
  local crypto = require("@zcore/crypto")
  local hash = crypto.hash.sha2.sha256("Hello World!")
  local hmac = crypto.hmac.sha2.sha256("Hello World!", "private key")
  local pass_hash = crypto.password.hash("pass")

  print(crypto.password.verify("pass", pass_hash))
  ```

### Changed
- Partial backend code for print formating.
- Internal package.