### PR TITLE
Better Color Output & Upgrade `zig-luau`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -96,7 +96,9 @@ jobs:
 
     - name: Run tests
       continue-on-error: ${{ matrix.qemu-platform != '' }}
-      run: NO_COLOR="0" zig build test -Dtarget=${{ matrix.target }}${{ matrix.qemu-platform != '' && ' -fqemu' || '' }} --verbose
+      run: zig build test -Dtarget=${{ matrix.target }}${{ matrix.qemu-platform != '' && ' -fqemu' || '' }} --verbose
+      env:
+        NO_COLOR: 0
    
     - name: Build debug
       run: zig build -Dtarget=${{ matrix.target }} --verbose

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -97,8 +97,6 @@ jobs:
     - name: Run tests
       continue-on-error: ${{ matrix.qemu-platform != '' }}
       run: zig build test -Dtarget=${{ matrix.target }}${{ matrix.qemu-platform != '' && ' -fqemu' || '' }} --verbose
-      env:
-        NO_COLOR: 0
    
     - name: Build debug
       run: zig build -Dtarget=${{ matrix.target }} --verbose

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -96,7 +96,7 @@ jobs:
 
     - name: Run tests
       continue-on-error: ${{ matrix.qemu-platform != '' }}
-      run: zig build test -Dtarget=${{ matrix.target }}${{ matrix.qemu-platform != '' && ' -fqemu' || '' }} --verbose
+      run: NO_COLOR="0" zig build test -Dtarget=${{ matrix.target }}${{ matrix.qemu-platform != '' && ' -fqemu' || '' }} --verbose
    
     - name: Build debug
       run: zig build -Dtarget=${{ matrix.target }} --verbose

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -16,8 +16,8 @@
             .hash = "lz4-0.2.0-OvBcTytgAAC95acrxK1s8UwtlTWR-7J4UvEkgstnvN1p",
         },
         .luau = .{
-            .url = "https://codeload.github.com/Scythe-Technology/zig-luau/tar.gz/0c5eb2ddab7998ecb5eca7b995cf206a2477fdbb",
-            .hash = "luau-0.4.0+678-5FZzCSDNBQCHahTGjdOvBGAGJ37h884ZXL3miFf4fUDJ",
+            .url = "https://codeload.github.com/Scythe-Technology/zig-luau/tar.gz/b81a291423ae4b782cc067653a5b803b29748525",
+            .hash = "luau-0.4.0+678-5FZzCb-HBgCjwdEqIMOJIBlCao3f1fQ4UPdrBuExCHhI",
         },
         .pcre2 = .{
             .url = "https://codeload.github.com/Scythe-Technology/zpcre2/tar.gz/9e6a4e39b585e6ab6b759a949469755625e81418",

--- a/src/commands/execution.zig
+++ b/src/commands/execution.zig
@@ -263,9 +263,9 @@ fn cmdTest(allocator: std.mem.Allocator, args: []const []const u8) !void {
     defer {
         const result = gpa.deinit();
         if (result == .leak) {
-            std.debug.print(" \x1b[1;31m[Memory leaks detected]\x1b[0m\n", .{});
-            std.debug.print(" This is likely a zune bug, report it on the zune repository.\n", .{});
-            std.debug.print(" \x1b[4mhttps://github.com/Scythe-Technology/Zune\x1b[0m\n\n", .{});
+            Zune.debug.print(" <bold><red>[Memory leaks detected]<clear>\n", .{});
+            Zune.debug.print(" This is likely a zune bug, report it on the zune repository.\n", .{});
+            Zune.debug.print(" <underline>https://github.com/Scythe-Technology/Zune<clear>\n\n", .{});
         }
     }
 

--- a/src/commands/help.zig
+++ b/src/commands/help.zig
@@ -1,26 +1,28 @@
 const std = @import("std");
 
+const Zune = @import("zune");
+
 const command = @import("lib.zig");
 
 fn Execute(_: std.mem.Allocator, _: []const []const u8) !void {
-    std.debug.print("\x1b[1;3;37mZ\x1b[2;3mune\x1b[0m - A luau runtime\n" ++
+    Zune.debug.print("<bold><dim>Z<clear><bold>UNE<clear> - A luau runtime\n" ++
         "\n" ++
-        "\x1b[1mUsage:\x1b[0m zune \x1b[2m<command> [...args]\x1b[0m\n" ++
+        "<bold>Usage:<clear> zune <dim><<command>> [...args]<clear>\n" ++
         "\n" ++
-        "\x1b[1mCommands:\x1b[0m\n" ++
-        "  \x1b[1;32mrun      \x1b[0;2m./script.luau    \x1b[0mExecute lua/luau file.\n" ++
-        "  \x1b[1;32mtest     \x1b[0;2m./test.luau      \x1b[0mRun tests in lua/luau file, similar to run.\n" ++
-        "  \x1b[1;32msetup    \x1b[0;2m[editor]         \x1b[0mSetup environment for luau-lsp with editor of your choice.\n" ++
-        "  \x1b[1;32mrepl                      \x1b[0mStart REPL session.\n" ++
-        "  \x1b[1;32minit                      \x1b[0mCreate initial files & configs for zune.\n" ++
+        "<bold>Commands:<clear>\n" ++
+        "  <bold><green>run      <clear><dim>./script.luau    <clear>Execute lua/luau file.\n" ++
+        "  <bold><green>test     <clear><dim>./test.luau      <clear>Run tests in lua/luau file, similar to run.\n" ++
+        "  <bold><green>setup    <clear><dim>[editor]         <clear>Setup environment for luau-lsp with editor of your choice.\n" ++
+        "  <bold><green>repl                      <clear>Start REPL session.\n" ++
+        "  <bold><green>init                      <clear>Create initial files & configs for zune.\n" ++
         "\n" ++
-        "  \x1b[1;34mluau     \x1b[0;2m[args...]        \x1b[0mDisplay info from luau.\n" ++
-        "  \x1b[1;34mhelp                      \x1b[0mDisplay help message.\n" ++
+        "  <bold><blue>luau     <clear><dim>[args...]        <clear>Display info from luau.\n" ++
+        "  <bold><blue>help                      <clear>Display help message.\n" ++
         "\n" ++
-        "\x1b[1mFlags:\x1b[0m\n" ++
-        "  -e, --eval     \x1b[0;2m[luau]     \x1b[0mEvaluate luau code.\n" ++
-        "  -V, --version             \x1b[0mDisplay version.\n" ++
-        "  -h, --help                \x1b[0mDisplay help message.\n" ++
+        "<bold>Flags:<clear>\n" ++
+        "  -e, --eval     <clear><dim>[luau]     <clear>Evaluate luau code.\n" ++
+        "  -V, --version             <clear>Display version.\n" ++
+        "  -h, --help                <clear>Display help message.\n" ++
         "", .{});
 }
 

--- a/src/commands/luau.zig
+++ b/src/commands/luau.zig
@@ -1,9 +1,9 @@
 const std = @import("std");
 const luau = @import("luau");
 
-const command = @import("lib.zig");
+const Zune = @import("zune");
 
-const zune_info = @import("zune-info");
+const command = @import("lib.zig");
 
 const USAGE = "Usage: luau <list-fflags | version>\n";
 fn Execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
@@ -12,36 +12,60 @@ fn Execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     }
 
     if (std.mem.eql(u8, args[0], "list-fflags")) {
-        const flags = try luau.Flags.getFlags(allocator);
-        defer flags.deinit();
-
         var long_name: usize = 0;
-        for (flags.flags) |flag| long_name = @max(long_name, flag.name.len);
 
-        for (flags.flags) |flag| {
-            const pad_size = (long_name - flag.name.len) + 2;
+        const bool_flags = luau.FFlags.Get(bool);
+        const int_flags = luau.FFlags.Get(i32);
 
-            var padding = try allocator.alloc(u8, pad_size);
-            defer allocator.free(padding);
+        {
+            var iter = bool_flags.iterator();
+            while (iter.next()) |flag|
+                long_name = @max(long_name, std.mem.span(flag.name).len);
+            var iter2 = int_flags.iterator();
+            while (iter2.next()) |flag|
+                long_name = @max(long_name, std.mem.span(flag.name).len);
+        }
 
-            for (0..pad_size) |i| padding[i] = '.';
+        {
+            inline for (&[_]type{ bool, i32 }) |t| {
+                const flags = luau.FFlags.Get(t);
+                var iter = flags.iterator();
+                while (iter.next()) |flag| {
+                    const name = std.mem.span(flag.name);
+                    const pad_size = (long_name - name.len) + 2;
 
-            const string_value = switch (flag.type) {
-                .boolean => if (try luau.Flags.getBoolean(flag.name)) "\x1b[1;32mtrue\x1b[0m" else "\x1b[1;31mfalse\x1b[0m",
-                .integer => try std.fmt.allocPrint(allocator, " \x1b[1;33m{d}\x1b[0m", .{try luau.Flags.getInteger(flag.name)}),
-            };
+                    var padding = try allocator.alloc(u8, pad_size);
+                    defer allocator.free(padding);
 
-            defer if (flag.type == .integer) allocator.free(string_value);
+                    for (0..pad_size) |i|
+                        padding[i] = '.';
 
-            std.debug.print("\x1b[1m{s} \x1b[2m{s}\x1b[0m = ({s}) {s}\n", .{
-                flag.name,
-                padding,
-                switch (flag.type) {
-                    .boolean => "\x1b[1;33mbool\x1b[0m",
-                    .integer => "\x1b[1;96mint\x1b[0m",
-                },
-                string_value,
-            });
+                    if (t == bool) {
+                        if (flag.value) Zune.debug.print(
+                            "<bold>{s} <dim>{s}<clear> = (<bold><yellow>bool<clear>) <bold><green>true<clear>\n",
+                            .{
+                                name,
+                                padding,
+                            },
+                        ) else Zune.debug.print(
+                            "<bold>{s} <dim>{s}<clear> = (<bold><yellow>bool<clear>) <bold><red>false<clear>\n",
+                            .{
+                                name,
+                                padding,
+                            },
+                        );
+                    } else {
+                        Zune.debug.print(
+                            "<bold>{s} <dim>{s}<clear> = (<bold><bcyan>int<clear>)  <bold><yellow>{d}<clear>\n",
+                            .{
+                                name,
+                                padding,
+                                flag.value,
+                            },
+                        );
+                    }
+                }
+            }
         }
     } else if (std.mem.eql(u8, args[0], "version")) {
         std.debug.print("{}.{}", .{ luau.LUAU_VERSION.major, luau.LUAU_VERSION.minor });

--- a/src/core/lua/testing_lib.luau
+++ b/src/core/lua/testing_lib.luau
@@ -40,17 +40,19 @@ local DEFER_QUEUE = {}::{()->()};
 local SCOPE_STACK = {}::{string};
 local TEST_STACK = {}::{string};
 
-local RESET = "\27[0m";
+local useColor = (zune.process.env["NO_COLOR"] == nil or zune.process.env["NO_COLOR"] == "0");
 
-local DIM = "\27[2m";
-local BOLD = "\27[1m";
-local UNDERLINE = "\27[4m";
+local RESET = if (useColor) then "\27[0m" else "";
 
-local WHITE = "\27[37m";
-local RED = "\27[31m";
-local BLUE = "\27[34m";
-local GREEN = "\27[32m";
-local YELLOW = "\27[33m";
+local DIM = if (useColor) then "\27[2m" else "";
+local BOLD = if (useColor) then "\27[1m" else "";
+local UNDERLINE = if (useColor) then "\27[4m" else "";
+
+local WHITE = if (useColor) then "\27[37m" else "";
+local RED = if (useColor) then "\27[31m" else "";
+local BLUE = if (useColor) then "\27[34m" else "";
+local GREEN = if (useColor) then "\27[32m" else "";
+local YELLOW = if (useColor) then "\27[33m" else "";
 
 function paddedNumber(line: number, longest: number, padding: string): string
     return `{line}{string.rep(padding, longest - #tostring(line))}`

--- a/src/core/runtime/engine.zig
+++ b/src/core/runtime/engine.zig
@@ -51,15 +51,15 @@ pub fn setLuaFileContext(L: *VM.lua.State, ctx: FileContext) void {
 
 pub fn printSpacedPadding(padding: []u8) void {
     @memset(padding, ' ');
-    std.debug.print("{s}|\n", .{padding});
+    Zune.debug.print("{s}|\n", .{padding});
 }
 
 pub fn printPreviewError(padding: []u8, line: u32, comptime fmt: []const u8, args: anytype) void {
-    std.debug.print("{s}|\n", .{padding});
+    Zune.debug.print("{s}|\n", .{padding});
     _ = std.fmt.bufPrint(padding, "{d}", .{line}) catch |e| std.debug.panic("{}", .{e});
-    std.debug.print("{s}~ \x1b[2mPreviewError: " ++ fmt ++ "\x1b[0m\n", .{padding} ++ args);
+    Zune.debug.print("{s}~ <dim>PreviewError: " ++ fmt ++ "<clear>\n", .{padding} ++ args);
     @memset(padding, ' ');
-    std.debug.print("{s}|\n", .{padding});
+    Zune.debug.print("{s}|\n", .{padding});
 }
 
 pub fn logDetailedDef(L: *VM.lua.State, idx: i32) !void {
@@ -121,9 +121,9 @@ pub fn logDetailedDef(L: *VM.lua.State, idx: i32) !void {
     if (stackInfo != null and stackInfo.?.what == .lua and stackInfo.?.source_line != null) {
         const info = stackInfo.?;
         if (!L.checkstack(4)) {
-            std.debug.print("Failed to show detailed error: StackOverflow\n", .{});
-            std.debug.print("\x1b[32merror\x1b[0m: {s}\n", .{err_msg});
-            std.debug.print("{s}\n", .{L.debugtrace()});
+            Zune.debug.print("Failed to show detailed error: StackOverflow\n", .{});
+            Zune.debug.print("<red>error<clear>: {s}\n", .{err_msg});
+            Zune.debug.print("{s}\n", .{L.debugtrace()});
             return;
         }
 
@@ -146,14 +146,14 @@ pub fn logDetailedDef(L: *VM.lua.State, idx: i32) !void {
                 err_msg = err_msg[p + strip.len ..];
         }
 
-        std.debug.print("\x1b[31merror\x1b[0m: {s}\n", .{err_msg});
+        Zune.debug.print("<red>error<clear>: {s}\n", .{err_msg});
 
         const padded_string = try allocator.alloc(u8, padding + 1);
         defer allocator.free(padded_string);
         @memset(padded_string, ' ');
 
         if (info.source) |src| {
-            std.debug.print("\x1b[1;4m{s}:{d}\x1b[0m\n", .{
+            Zune.debug.print("<bold><underline>{s}:{d}<clear>\n", .{
                 if (src.len > 1 and src[0] == '@') src[1..] else src,
                 source_line,
             });
@@ -190,24 +190,21 @@ pub fn logDetailedDef(L: *VM.lua.State, idx: i32) !void {
             };
             defer allocator.free(line_content);
 
-            std.debug.print("{s}|\n", .{padded_string});
+            Zune.debug.print("{s}|\n", .{padded_string});
             _ = std.fmt.bufPrint(padded_string, "{d}", .{source_line}) catch |e| std.debug.panic("{}", .{e});
-            std.debug.print("{s}| {s}\n", .{ padded_string, line_content });
+            Zune.debug.print("{s}| {s}\n", .{ padded_string, line_content });
             @memset(padded_string, ' ');
-            std.debug.print("{s}|\n", .{padded_string});
+            Zune.debug.print("{s}|\n", .{padded_string});
         }
     } else {
-        std.debug.print("\x1b[32merror\x1b[0m: {s}\n", .{err_msg});
-        std.debug.print("{s}\n", .{L.debugtrace()});
+        Zune.debug.print("<green>error<clear>: {s}\n", .{err_msg});
+        Zune.debug.print("{s}\n", .{L.debugtrace()});
         return;
     }
 }
 
 pub fn logFnDef(L: *VM.lua.State, idx: i32) void {
-    if (L.typeOf(idx) != .Function) {
-        std.debug.print("logFnDef: Expected function\n", .{});
-        return;
-    }
+    std.debug.assert(L.typeOf(idx) == .Function);
     logDetailedDef(L, idx) catch |e| std.debug.panic("{}", .{e});
 }
 
@@ -267,15 +264,15 @@ pub fn logDetailedError(L: *VM.lua.State) !void {
     }
 
     if (list.items.len < 1) {
-        std.debug.print("\x1b[32merror\x1b[0m: {s}\n", .{err_msg});
-        std.debug.print("{s}\n", .{L.debugtrace()});
+        Zune.debug.print("<green>error<clear>: {s}\n", .{err_msg});
+        Zune.debug.print("{s}\n", .{L.debugtrace()});
         return;
     }
 
     if (!L.checkstack(5)) {
-        std.debug.print("Failed to show detailed error: StackOverflow\n", .{});
-        std.debug.print("\x1b[32merror\x1b[0m: {s}\n", .{err_msg});
-        std.debug.print("{s}\n", .{L.debugtrace()});
+        Zune.debug.print("Failed to show detailed error: StackOverflow\n", .{});
+        Zune.debug.print("<green>error<clear>: {s}\n", .{err_msg});
+        Zune.debug.print("{s}\n", .{L.debugtrace()});
         return;
     }
 
@@ -316,7 +313,7 @@ pub fn logDetailedError(L: *VM.lua.State) !void {
     }
     const padding = std.math.log10(largest_line) + 1;
 
-    std.debug.print("\x1b[31merror\x1b[0m: {s}\n", .{err_msg});
+    Zune.debug.print("<red>error<clear>: {s}\n", .{err_msg});
 
     const padded_string = try allocator.alloc(u8, padding + 1);
     defer allocator.free(padded_string);
@@ -330,7 +327,7 @@ pub fn logDetailedError(L: *VM.lua.State) !void {
         if (info.source) |src| blk: {
             const current_line = info.current_line.?;
 
-            std.debug.print("\x1b[1;4m{s}:{d}\x1b[0m\n", .{
+            Zune.debug.print("<bold><underline>{s}:{d}<clear>\n", .{
                 if (src.len > 1 and src[0] == '@') src[1..] else src,
                 current_line,
             });
@@ -380,9 +377,9 @@ pub fn logDetailedError(L: *VM.lua.State) !void {
             };
             defer allocator.free(line_content);
 
-            std.debug.print("{s}|\n", .{padded_string});
+            Zune.debug.print("{s}|\n", .{padded_string});
             _ = std.fmt.bufPrint(padded_string, "{d}", .{current_line}) catch |e| std.debug.panic("{}", .{e});
-            std.debug.print("{s}| {s}\n", .{ padded_string, line_content });
+            Zune.debug.print("{s}| {s}\n", .{ padded_string, line_content });
             @memset(padded_string, ' ');
 
             if (reference_level != null and reference_level.? == lvl) {
@@ -397,9 +394,9 @@ pub fn logDetailedError(L: *VM.lua.State) !void {
 
                 @memset(buf, '^');
 
-                std.debug.print("{s}| {s}\x1b[31m{s}\x1b[0m\n", .{ padded_string, space_slice, buf });
+                Zune.debug.print("{s}| {s}<red>{s}<clear>\n", .{ padded_string, space_slice, buf });
             } else {
-                std.debug.print("{s}|\n", .{padded_string});
+                Zune.debug.print("{s}|\n", .{padded_string});
             }
         }
     }
@@ -412,10 +409,10 @@ pub fn logError(L: *VM.lua.State, err: anyerror, forceDetailed: bool) void {
                 logDetailedError(L) catch |e| std.debug.panic("{}", .{e});
             } else {
                 switch (L.typeOf(-1)) {
-                    .String, .Number => std.debug.print("{s}\n", .{L.tostring(-1).?}),
+                    .String, .Number => Zune.debug.print("{s}\n", .{L.tostring(-1).?}),
                     else => jmp: {
                         if (!L.checkstack(2)) {
-                            std.debug.print("StackOverflow\n", .{});
+                            Zune.debug.print("StackOverflow\n", .{});
                         }
                         const TL = L.newthread();
                         defer L.pop(1); // drop: thread
@@ -429,14 +426,14 @@ pub fn logError(L: *VM.lua.State, err: anyerror, forceDetailed: bool) void {
                             }
                             break :jmp;
                         };
-                        std.debug.print("{s}\n", .{str});
+                        Zune.debug.print("{s}\n", .{str});
                     },
                 }
-                std.debug.print("{s}\n", .{L.debugtrace()});
+                Zune.debug.print("{s}\n", .{L.debugtrace()});
             }
         },
         else => {
-            std.debug.print("Error: {}\n", .{err});
+            Zune.debug.print("Error: {}\n", .{err});
         },
     }
 }
@@ -469,8 +466,8 @@ pub fn prepAsync(L: *VM.lua.State, sched: *Scheduler) !void {
 pub fn stateCleanUp() void {
     if (Zune.corelib.io.TERMINAL) |*terminal| {
         if (terminal.stdout_istty and terminal.stdin_istty) {
-            terminal.restoreSettings() catch std.debug.print("[Zune] Failed to restore terminal settings\n", .{});
-            terminal.restoreOutputMode() catch std.debug.print("[Zune] Failed to restore terminal output mode\n", .{});
+            terminal.restoreSettings() catch Zune.debug.print("[Zune] Failed to restore terminal settings\n", .{});
+            terminal.restoreOutputMode() catch Zune.debug.print("[Zune] Failed to restore terminal output mode\n", .{});
         }
     }
 }

--- a/src/core/standard/net/http/server/client.zig
+++ b/src/core/standard/net/http/server/client.zig
@@ -475,7 +475,8 @@ pub fn ws_upgradeResumed(self: *Self, L: *VM.lua.State, _: *Scheduler) void {
     if (top < 3) { // only a lua function could have less than 3 on top
         @branchHint(.unlikely);
         L.pushlstring("Upgrade must return a boolean");
-        Engine.logFnDef(L, -2);
+        if (L.typeOf(-2) == .Function)
+            Engine.logFnDef(L, -2);
         self.state.stage = .closing;
         self.writeAll(HTTP_500);
         return;
@@ -483,7 +484,8 @@ pub fn ws_upgradeResumed(self: *Self, L: *VM.lua.State, _: *Scheduler) void {
         @branchHint(.unlikely);
         L.pop(@intCast(top - 2));
         L.pushlstring("Upgrade returned too many values");
-        Engine.logFnDef(L, -2);
+        if (L.typeOf(-2) == .Function)
+            Engine.logFnDef(L, -2);
         self.state.stage = .closing;
         self.writeAll(HTTP_500);
         return;
@@ -494,7 +496,8 @@ pub fn ws_upgradeResumed(self: *Self, L: *VM.lua.State, _: *Scheduler) void {
         else => {
             L.pop(1);
             L.pushlstring("Upgrade must return a boolean");
-            Engine.logFnDef(L, -2);
+            if (L.typeOf(-2) == .Function)
+                Engine.logFnDef(L, -2);
             self.state.stage = .closing;
             self.writeAll(HTTP_500);
             return;
@@ -735,15 +738,18 @@ pub fn requestResumed(self: *Self, L: *VM.lua.State, _: *Scheduler) void {
         @branchHint(.unlikely);
         L.pop(@intCast(top - 1));
         L.pushlstring("Request returned too many values");
-        Engine.logFnDef(L, -2);
+        if (L.typeOf(-2) == .Function)
+            Engine.logFnDef(L, -2);
         self.state.stage = .closing;
         self.writeAll(HTTP_500);
         return;
     }
 
     self.processResponse(allocator, L) catch |err| {
-        if (err == error.Runtime)
-            Engine.logFnDef(L, -2);
+        if (err == error.Runtime) {
+            if (L.typeOf(-2) == .Function)
+                Engine.logFnDef(L, -2);
+        }
         self.state.stage = .closing;
         self.writeAll(HTTP_500);
         return;

--- a/src/core/standard/testing.zig
+++ b/src/core/standard/testing.zig
@@ -21,7 +21,7 @@ pub var REF_LEAK_CHECK = false;
 
 fn testing_debug(L: *VM.lua.State) i32 {
     const str = L.Lcheckstring(1);
-    std.debug.print("{s}\n", .{str});
+    Zune.debug.print("{s}\n", .{str});
     return 0;
 }
 
@@ -182,26 +182,26 @@ pub fn finish_testing(L: *VM.lua.State, rawstart: f64) TestResult {
             const refIdx = idx + 1;
             if (!header) {
                 header = true;
-                std.debug.print("\n", .{});
-                std.debug.print("\x1b[1;34mLEAK\x1b[0m Runtime leaked references (Information may not be accurate)\x1b[0m", .{});
+                Zune.debug.print("\n", .{});
+                Zune.debug.print("<bold><blue>LEAK<clear> Runtime leaked references (Information may not be accurate)<clear>", .{});
             }
-            std.debug.print("\n {s}\x1b[0m", .{source.scope});
-            std.debug.print("\n  \x1b[96m{}\x1b[0m \x1b[2m-\x1b[0m {s}", .{ refIdx, source.value });
+            Zune.debug.print("\n {s}<clear>", .{source.scope});
+            Zune.debug.print("\n  <bcyan>{}<clear> <dim>-<clear> {s}", .{ refIdx, source.value });
 
             freeRefTrace(allocator, idx);
         }
     }
     if (header)
-        std.debug.print("\n", .{});
+        Zune.debug.print("\n", .{});
 
     if (stdOut) {
-        std.debug.print("\n", .{});
+        Zune.debug.print("\n", .{});
         if (mainFailedCount > 0) {
-            std.debug.print(" \x1b[1mTests\x1b[0m: \x1b[1;31m{} failed\x1b[0m, {} total\n", .{ mainFailedCount, mainTestCount });
+            Zune.debug.print(" <bold>Tests<clear>: <bold><red>{} failed<clear>, {} total\n", .{ mainFailedCount, mainTestCount });
         } else {
-            std.debug.print(" \x1b[1mTests\x1b[0m: {} total\n", .{mainTestCount});
+            Zune.debug.print(" <bold>Tests<clear>: {} total\n", .{mainTestCount});
         }
-        std.debug.print(" \x1b[1mTime\x1b[0m:  {d} s\n", .{std.math.ceil(time * 1000) / 1000});
+        Zune.debug.print(" <bold>Time<clear>:  {d} s\n", .{std.math.ceil(time * 1000) / 1000});
     }
     return .{
         .failed = mainFailedCount,
@@ -247,7 +247,7 @@ pub fn loadLib(L: *VM.lua.State, enabled: bool) void {
         ML.load("test_framework", bytecode_buf, 0) catch |err|
             std.debug.panic("Error loading test framework: {}\n", .{err});
         _ = ML.pcall(0, 1, 0).check() catch |err| {
-            std.debug.print("Error loading test framework (2): {}\n", .{err});
+            Zune.debug.print("Error loading test framework (2): {}\n", .{err});
             Engine.logError(ML, err, false);
             std.debug.panic("Test Framework (2)\n", .{});
         };

--- a/src/core/utils/print.zig
+++ b/src/core/utils/print.zig
@@ -119,7 +119,7 @@ pub fn print(comptime fmt: []const u8, args: anytype) void {
     }
 }
 
-pub fn printWriter(writer: anytype, comptime fmt: []const u8, args: anytype) !void {
+pub fn writerPrint(writer: anytype, comptime fmt: []const u8, args: anytype) !void {
     if (Zune.STATE.FORMAT.USE_COLOR == true and std.mem.eql(u8, Zune.STATE.ENV_MAP.get("NO_COLOR") orelse "0", "0")) {
         const color_format = comptime ColorFormat(fmt, true);
         try writer.print(color_format, args);

--- a/src/core/utils/print.zig
+++ b/src/core/utils/print.zig
@@ -1,0 +1,130 @@
+const std = @import("std");
+
+const Zune = @import("zune");
+
+const ColorMap = std.StaticStringMap([]const u8).initComptime(.{
+    .{ "red", "31" },
+    .{ "green", "32" },
+    .{ "yellow", "33" },
+    .{ "blue", "34" },
+    .{ "magenta", "35" },
+    .{ "cyan", "36" },
+    .{ "white", "37" },
+    .{ "black", "30" },
+
+    .{ "bblack", "90" },
+    .{ "bred", "91" },
+    .{ "bgreen", "92" },
+    .{ "byellow", "93" },
+    .{ "bblue", "94" },
+    .{ "bmagenta", "95" },
+    .{ "bcyan", "96" },
+    .{ "bwhite", "97" },
+
+    .{ "bold", "1" },
+    .{ "dim", "2" },
+    .{ "italic", "3" },
+    .{ "underline", "4" },
+    .{ "blink", "5" },
+    .{ "reverse", "7" },
+    .{ "clear", "0" },
+});
+
+fn ColorFormat(comptime fmt: []const u8, comptime use_colors: bool) []const u8 {
+    comptime var new_fmt: []const u8 = "";
+
+    comptime var start = -1;
+    comptime var ignore_next = false;
+    comptime var closed = true;
+    @setEvalBranchQuota(200_000);
+    comptime for (fmt, 0..) |c, i| switch (c) {
+        '<' => {
+            if (ignore_next) {
+                if (!closed) {
+                    if (use_colors)
+                        new_fmt = new_fmt ++ &[_]u8{'m'};
+                    closed = true;
+                }
+                new_fmt = new_fmt ++ &[_]u8{c};
+                ignore_next = false;
+                continue;
+            }
+            if (i + 1 < fmt.len and fmt[i + 1] == '<') {
+                ignore_next = true;
+                continue;
+            }
+            if (use_colors) {
+                if (!closed)
+                    new_fmt = new_fmt ++ &[_]u8{';'}
+                else
+                    new_fmt = new_fmt ++ "\x1b[";
+            }
+            if (start >= 0)
+                @compileError("Nested color tags in format string: " ++ fmt);
+            closed = false;
+            start = i;
+        },
+        '>' => {
+            if (ignore_next) {
+                if (!closed) {
+                    if (use_colors)
+                        new_fmt = new_fmt ++ &[_]u8{'m'};
+                    closed = true;
+                }
+                new_fmt = new_fmt ++ &[_]u8{c};
+                ignore_next = false;
+                continue;
+            }
+            if (i + 1 < fmt.len and fmt[i + 1] == '>') {
+                ignore_next = true;
+                continue;
+            }
+            if (start >= 0) {
+                const color_name = fmt[start + 1 .. i];
+                const code = ColorMap.get(color_name) orelse @compileError("Unknown color: " ++ color_name);
+                if (use_colors)
+                    new_fmt = new_fmt ++ code;
+                start = -1;
+            } else @compileError("Unmatched closing color tag in format string: " ++ fmt);
+        },
+        else => if (start < 0) {
+            if (!closed) {
+                if (use_colors)
+                    new_fmt = new_fmt ++ &[_]u8{'m'};
+                closed = true;
+            }
+            new_fmt = new_fmt ++ &[_]u8{c};
+        },
+    };
+    if (!closed) {
+        if (use_colors)
+            new_fmt = new_fmt ++ &[_]u8{'m'};
+    }
+    if (start >= 0)
+        @compileError("Unclosed color tag in format string: " ++ fmt);
+    return new_fmt;
+}
+
+pub fn print(comptime fmt: []const u8, args: anytype) void {
+    std.debug.lockStdErr();
+    defer std.debug.unlockStdErr();
+    const stderr = std.io.getStdErr().writer();
+
+    if (Zune.STATE.FORMAT.USE_COLOR == true and std.mem.eql(u8, Zune.STATE.ENV_MAP.get("NO_COLOR") orelse "0", "0")) {
+        const color_format = comptime ColorFormat(fmt, true);
+        nosuspend stderr.print(color_format, args) catch return;
+    } else {
+        const color_format = comptime ColorFormat(fmt, false);
+        nosuspend stderr.print(color_format, args) catch return;
+    }
+}
+
+pub fn printWriter(writer: anytype, comptime fmt: []const u8, args: anytype) !void {
+    if (Zune.STATE.FORMAT.USE_COLOR == true and std.mem.eql(u8, Zune.STATE.ENV_MAP.get("NO_COLOR") orelse "0", "0")) {
+        const color_format = comptime ColorFormat(fmt, true);
+        try writer.print(color_format, args);
+    } else {
+        const color_format = comptime ColorFormat(fmt, false);
+        try writer.print(color_format, args);
+    }
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -2,6 +2,7 @@ const xev = @import("xev");
 const std = @import("std");
 const luau = @import("luau");
 const json = @import("json");
+const mimalloc = @import("mimalloc");
 const builtin = @import("builtin");
 
 const toml = @import("libraries/toml.zig");
@@ -40,7 +41,12 @@ pub const Utils = struct {
     pub const LuaHelper = @import("core/utils/luahelper.zig");
 };
 
-const zune_info = @import("zune-info");
+pub const debug = struct {
+    pub const print = @import("core/utils/print.zig").print;
+    pub const printWriter = @import("core/utils/print.zig").printWriter;
+};
+
+pub const info = @import("zune-info");
 
 const VM = luau.VM;
 
@@ -61,7 +67,7 @@ pub const Flags = struct {
 
 pub var CONFIGURATIONS = .{.format_max_depth};
 
-pub const VERSION = "Zune " ++ zune_info.version ++ "+" ++ std.fmt.comptimePrint("{d}.{d}", .{ luau.LUAU_VERSION.major, luau.LUAU_VERSION.minor });
+pub const VERSION = "Zune " ++ info.version ++ "+" ++ std.fmt.comptimePrint("{d}.{d}", .{ luau.LUAU_VERSION.major, luau.LUAU_VERSION.minor });
 
 var STD_ENABLED = true;
 const FEATURES = struct {
@@ -148,10 +154,10 @@ pub fn loadConfiguration(dir: std.fs.Dir) void {
                 var iter = fflags_config.table.iterator();
                 while (iter.next()) |entry| {
                     switch (entry.value_ptr.*) {
-                        .boolean => luau.Flags.setBoolean(entry.key_ptr.*, entry.value_ptr.*.boolean) catch |err| {
+                        .boolean => luau.FFlags.SetByName(bool, entry.key_ptr.*, entry.value_ptr.*.boolean) catch |err| {
                             std.debug.print("[zune.toml] FFlag ({s}): {}\n", .{ entry.key_ptr.*, err });
                         },
-                        .integer => luau.Flags.setInteger(entry.key_ptr.*, @truncate(entry.value_ptr.*.integer)) catch |err| {
+                        .integer => luau.FFlags.SetByName(i32, entry.key_ptr.*, @truncate(entry.value_ptr.*.integer)) catch |err| {
                             std.debug.print("[zune.toml] FFlag ({s}): {}\n", .{ entry.key_ptr.*, err });
                         },
                         else => |t| std.debug.print("[zune.toml] Unsupported type for FFlags: {s}\n", .{@tagName(t)}),

--- a/src/main.zig
+++ b/src/main.zig
@@ -43,7 +43,7 @@ pub const Utils = struct {
 
 pub const debug = struct {
     pub const print = @import("core/utils/print.zig").print;
-    pub const printWriter = @import("core/utils/print.zig").printWriter;
+    pub const writerPrint = @import("core/utils/print.zig").writerPrint;
 };
 
 pub const info = @import("zune-info");

--- a/test/standard/io.test.luau
+++ b/test/standard/io.test.luau
@@ -306,12 +306,16 @@ describe("IO", function()
     end)
 
     test("Format", function()
+        local useColor = (zune.process.env["NO_COLOR"] == nil or zune.process.env["NO_COLOR"] == "0");
         expect(io.format("test")).toBe("test");
-        expect(io.format(123)).toBe("\x1B[96m123\x1B[0m");
+        expect(io.format(123)).toBe(if (useColor) then "\x1B[96m123\x1B[0m" else "123");
         local res : string = io.format({[" "] = 1});
         local start : number = (res:find(">")) or error("Bad format");
         start += 1;
-        expect(res:sub(start)).toBe(" {\x1B[0m\n    \x1B[2m[\x1B[0;32m\" \"\x1B[0;2m]\x1B[0m\x1B[2m = \x1B[0m\x1B[96m1\x1B[0m\x1B[2m,\x1B[0m \n\x1B[2m}\x1B[0m");
-        expect(((res:sub(1,start)):find("\x1B%[2m<table: 0x.+>"))).never.toBeNil();
+        expect(res:sub(start)).toBe(
+            if (useColor) then " {\x1B[0m\n    \x1B[2m[\x1B[0;32m\" \"\x1B[0;2m]\x1B[0m\x1B[2m = \x1B[0m\x1B[96m1\x1B[0m\x1B[2m,\x1B[0m \n\x1B[2m}\x1B[0m"
+            else " {\n    [\" \"] = 1, \n}"
+        );
+        expect(((res:sub(1,start)):find(if (useColor) then "\x1B%[2m<table: 0x.+>" else "<table: 0x.+>"))).never.toBeNil();
     end)
 end)

--- a/test/standard/io.test.luau
+++ b/test/standard/io.test.luau
@@ -311,7 +311,7 @@ describe("IO", function()
         local res : string = io.format({[" "] = 1});
         local start : number = (res:find(">")) or error("Bad format");
         start += 1;
-        expect(res:sub(start)).toBe(" {\x1B[0m\n    \x1B[2m[\x1B[0m\x1B[32m\" \"\x1B[0m\x1B[2m]\x1B[0m\x1B[2m = \x1B[0m\x1B[96m1\x1B[0m\x1B[2m,\x1B[0m \n\x1B[2m}\x1B[0m");
+        expect(res:sub(start)).toBe(" {\x1B[0m\n    \x1B[2m[\x1B[0;32m\" \"\x1B[0;2m]\x1B[0m\x1B[2m = \x1B[0m\x1B[96m1\x1B[0m\x1B[2m,\x1B[0m \n\x1B[2m}\x1B[0m");
         expect(((res:sub(1,start)):find("\x1B%[2m<table: 0x.+>"))).never.toBeNil();
     end)
 end)


### PR DESCRIPTION
Configurable color output for all stderr print from zune.
Can now change with `NO_COLOR=1` environment variable or `resolvers.formatter.useColor = false` in config file.

Other changes:
- Upgrade `zig-luau` for updated FFlags api.