### PR TITLE
Add `random` library

### DIFF
--- a/src/core/standard/lib.zig
+++ b/src/core/standard/lib.zig
@@ -8,6 +8,7 @@ pub const regex = @import("regex.zig");
 pub const serde = @import("serde/lib.zig");
 pub const sqlite = @import("sqlite.zig");
 pub const crypto = @import("crypto/lib.zig");
+pub const random = @import("random.zig");
 pub const process = @import("process.zig");
 pub const require = @import("require.zig");
 pub const testing = @import("testing.zig");

--- a/src/core/standard/random.zig
+++ b/src/core/standard/random.zig
@@ -1,0 +1,175 @@
+const std = @import("std");
+const luau = @import("luau");
+const json = @import("json");
+
+const Zune = @import("zune");
+
+const LuaHelper = Zune.Utils.LuaHelper;
+const MethodMap = Zune.Utils.MethodMap;
+
+const VM = luau.VM;
+
+const tagged = @import("../../tagged.zig");
+
+const TAG_RANDOM = tagged.Tags.get("RANDOM").?;
+
+pub const LIB_NAME = "random";
+
+const LuaRandom = struct {
+    algorithm: Algorithm,
+
+    pub const Algorithm = union(enum) {
+        LuauPcg32: std.Random.Pcg,
+        Isaac64: std.Random.Isaac64,
+        Pcg32: std.Random.Pcg,
+        Xoroshiro128: std.Random.Xoroshiro128,
+        Xoshiro256: std.Random.Xoshiro256,
+        Sfc64: std.Random.Sfc64,
+        RomuTrio: std.Random.RomuTrio,
+
+        pub fn random(self: *Algorithm) std.Random {
+            return switch (self.*) {
+                inline else => |*algo| algo.random(),
+            };
+        }
+    };
+
+    fn lua_nextInteger(self: *LuaRandom, L: *VM.lua.State) !i32 {
+        const arg0 = try L.Zcheckvalue(i32, 2, null);
+        const arg1 = try L.Zcheckvalue(i32, 3, null);
+        const min = @min(arg0, arg1);
+        const max = @max(arg0, arg1);
+
+        L.pushinteger(self.algorithm.random().intRangeAtMost(i32, min, max));
+
+        return 1;
+    }
+
+    fn lua_nextNumber(self: *LuaRandom, L: *VM.lua.State) !i32 {
+        const min = try L.Zcheckvalue(?f64, 2, null);
+        const max = try L.Zcheckvalue(?f64, 3, null);
+
+        if (min == null or max == null) {
+            if (min != null or max != null)
+                return L.Zerror("both min and max must be provided");
+
+            L.pushnumber(self.algorithm.random().float(f64));
+        } else {
+            const value = self.algorithm.random().float(f64);
+
+            if (std.math.isNan(min.?) or std.math.isNan(max.?)) {
+                L.pushnumber(std.math.nan(f64));
+                return 1;
+            }
+            if (std.math.isInf(min.?) and std.math.isInf(max.?)) {
+                if (min.? > 0 and max.? > 0) {
+                    L.pushnumber(std.math.inf(f64));
+                } else if (min.? < 0 and max.? < 0) {
+                    L.pushnumber(std.math.inf(f64) * -1);
+                } else {
+                    L.pushnumber(std.math.nan(f64));
+                }
+                return 1;
+            }
+            if (std.math.isInf(min.?)) {
+                L.pushnumber(min.?);
+                return 1;
+            }
+            if (std.math.isInf(max.?)) {
+                L.pushnumber(max.?);
+                return 1;
+            }
+
+            const i_min = @min(min.?, max.?);
+            const i_max = @max(min.?, max.?);
+
+            L.pushnumber(value * (i_max - i_min) + i_min);
+        }
+
+        return 1;
+    }
+
+    fn lua_clone(self: *LuaRandom, L: *VM.lua.State) !i32 {
+        const random = L.newuserdatataggedwithmetatable(LuaRandom, TAG_RANDOM);
+        random.* = .{
+            .algorithm = self.algorithm,
+        };
+        return 1;
+    }
+
+    pub const __index = MethodMap.CreateStaticIndexMap(LuaRandom, TAG_RANDOM, .{
+        .{ "nextInteger", lua_nextInteger },
+        .{ "NextInteger", lua_nextInteger },
+        .{ "nextNumber", lua_nextNumber },
+        .{ "NextNumber", lua_nextInteger },
+        .{ "clone", lua_clone },
+        .{ "Clone", lua_clone },
+    });
+};
+
+fn lua_newLuauPcg32(L: *VM.lua.State) !i32 {
+    const seed = try L.Zcheckvalue(u32, 1, null);
+
+    var pcg32: std.Random.Pcg = .{
+        .s = 0,
+        .i = 105,
+    };
+
+    var dummy: [4]u8 = undefined;
+    pcg32.fill(&dummy);
+    pcg32.s += seed;
+    pcg32.fill(&dummy);
+
+    const hasher = L.newuserdatataggedwithmetatable(LuaRandom, TAG_RANDOM);
+    hasher.* = .{ .algorithm = .{ .LuauPcg32 = pcg32 } };
+    return 1;
+}
+
+fn NewGenerator(comptime name: []const u8) fn (L: *VM.lua.State) anyerror!i32 {
+    return struct {
+        fn inner(L: *VM.lua.State) !i32 {
+            const seed = try L.Zcheckvalue(u32, 1, null);
+            const hasher = L.newuserdatataggedwithmetatable(LuaRandom, TAG_RANDOM);
+            hasher.* = .{ .algorithm = @unionInit(LuaRandom.Algorithm, name, .init(@intCast(seed))) };
+            return 1;
+        }
+    }.inner;
+}
+
+pub fn loadLib(L: *VM.lua.State) void {
+    {
+        _ = L.Znewmetatable(@typeName(LuaRandom), .{
+            .__metatable = "Metatable is locked",
+            .__type = "Random",
+        });
+        LuaRandom.__index(L, -1);
+        L.setreadonly(-1, true);
+        L.setuserdatametatable(TAG_RANDOM);
+    }
+
+    L.Zpushvalue(.{
+        .new = lua_newLuauPcg32,
+        .LuauPcg32 = .{ .new = lua_newLuauPcg32 },
+        .Pcg32 = .{ .new = NewGenerator("Pcg32") },
+        .Isaac64 = .{ .new = NewGenerator("Isaac64") },
+        .Xoroshiro128 = .{ .new = NewGenerator("Xoroshiro128") },
+        .Xoshiro256 = .{ .new = NewGenerator("Xoshiro256") },
+        .Sfc64 = .{ .new = NewGenerator("Sfc64") },
+        .RomuTrio = .{ .new = NewGenerator("RomuTrio") },
+    });
+    L.setreadonly(-1, true);
+    LuaHelper.registerModule(L, LIB_NAME);
+}
+
+test "random" {
+    const TestRunner = @import("../utils/testrunner.zig");
+
+    const testResult = try TestRunner.runTest(
+        TestRunner.newTestFile("standard/random.test.luau"),
+        &.{},
+        .{},
+    );
+
+    try std.testing.expect(testResult.failed == 0);
+    try std.testing.expect(testResult.total > 0);
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -84,6 +84,7 @@ const FEATURES = struct {
     pub var regex = true;
     pub var sqlite = true;
     pub var require = true;
+    pub var random = true;
     pub var ffi = true;
 };
 
@@ -265,6 +266,8 @@ pub fn openZune(L: *VM.lua.State, args: []const []const u8, flags: Flags) !void 
             corelib.sqlite.loadLib(L);
         if (FEATURES.require)
             corelib.require.loadLib(L);
+        if (FEATURES.random)
+            corelib.random.loadLib(L);
 
         corelib.testing.loadLib(L, STATE.RUN_MODE == .Test);
     }

--- a/src/tagged.zig
+++ b/src/tagged.zig
@@ -14,6 +14,8 @@ const TagNames: []const []const u8 = &.{
     "PROCESS_CHILD",
     // CRYPTO
     "CRYPTO_HASHER",
+    // RANDOM
+    "RANDOM",
     // REGEX
     "REGEX_COMPILED",
     // FFI

--- a/src/types/global/zune.d.luau
+++ b/src/types/global/zune.d.luau
@@ -2157,6 +2157,36 @@ export type RequireLib = {
 }
 --[======[ Require ]======]--
 
+--[======[ Random ]======]--
+declare class Random
+    nextNumber:
+        & ((self: Random) -> number)
+        & ((self: Random, min: number, max: number) -> number)
+    NextNumber:
+        & ((self: Random) -> number)
+        & ((self: Random, min: number, max: number) -> number)
+    function nextInteger(self, min: number, max: number): number
+    function NextInteger(self, min: number, max: number): number
+    function clone(self): Random
+    function Clone(self): Random
+end
+
+type RandomConstructor = {
+    new: (seed: number) -> Random,
+}
+
+export type RandomLib = RandomConstructor & {
+    LuauPcg32: RandomConstructor,
+    Pcg32: RandomConstructor,
+    Isaac64: RandomConstructor,
+    Pcg32: RandomConstructor,
+    Xoroshiro128: RandomConstructor,
+    Xoshiro256: RandomConstructor,
+    Sfc64: RandomConstructor,
+    RomuTrio: RandomConstructor,
+}
+--[======[ Random ]======]--
+
 declare zune: {
     fs: FileSystemLib,
     process: ProcessLib,
@@ -2172,4 +2202,5 @@ declare zune: {
     ffi: FFILib,
     sqlite: SQLiteLib,
     require: RequireLib,
+    random: RandomLib,
 }

--- a/test/standard/random.test.luau
+++ b/test/standard/random.test.luau
@@ -1,0 +1,68 @@
+--!strict
+local random = zune.random;
+local testing = zune.testing;
+
+local describe = testing.describe;
+local expect = testing.expect;
+local test = testing.test;
+
+local function randomTest(impl: any)
+    local rand: Random = impl.new(0);
+    for i = 1, 20 do
+        local result = rand:nextInteger(0, 10);
+        expect(result).toBeGreaterThanOrEqual(0);
+        expect(result).toBeLessThanOrEqual(10);
+        expect(result // 1).toBe(result);
+    end
+    for i = 1, 20 do
+        local result = rand:nextNumber(0, 10);
+        expect(result).toBeGreaterThanOrEqual(0);
+        expect(result).toBeLessThanOrEqual(10);
+        expect(result // 1).never.toBe(result);
+    end
+
+    expect(rand:nextNumber(0, math.huge)).toBe(math.huge);
+    expect(rand:nextNumber(math.huge, 0)).toBe(math.huge);
+    expect(rand:nextNumber(math.huge, math.huge)).toBe(math.huge);
+    expect(rand:nextNumber(0, -math.huge)).toBe(-math.huge);
+    expect(rand:nextNumber(-math.huge, 0)).toBe(-math.huge);
+    expect(rand:nextNumber(-math.huge, -math.huge)).toBe(-math.huge);
+    expect(tostring(rand:nextNumber(-math.huge, math.huge))).toBe(tostring(0/0));
+    expect(tostring(rand:nextNumber(math.huge, -math.huge))).toBe(tostring(0/0));
+    expect(tostring(rand:nextNumber(0/0, 0/0))).toBe(tostring(0/0));
+    expect(tostring(rand:nextNumber(0, 0/0))).toBe(tostring(0/0));
+    expect(tostring(rand:nextNumber(0/0, 0))).toBe(tostring(0/0));
+
+    local copy = rand:clone();
+    expect(copy:nextInteger(0, 10)).toBe(rand:nextInteger(0, 10));
+    copy:nextInteger(0, 10);
+    copy:nextInteger(0, 10);
+    expect(copy:nextInteger(0, 10)).never.toBe(rand:nextInteger(0, 10));
+end
+
+describe("Random", function()
+    test("Default", function()
+        randomTest(random);
+    end)
+    test("LuauPcg32", function()
+        randomTest(random.LuauPcg32);
+    end)
+    test("Isaac64", function()
+        randomTest(random.Isaac64);
+    end)
+    test("Pcg32", function()
+        randomTest(random.Pcg32);
+    end)
+    test("Xoroshiro128", function()
+        randomTest(random.Xoroshiro128);
+    end)
+    test("Xoshiro256", function()
+        randomTest(random.Xoshiro256);
+    end)
+    test("Sfc64", function()
+        randomTest(random.Sfc64);
+    end)
+    test("RomuTrio", function()
+        randomTest(random.RomuTrio);
+    end)
+end)


### PR DESCRIPTION
Adds `zune.random` library.

`random` generators
- `LuauPcg32`
- `Pcg32`
- `Isaac64`
- `Pcg32`
- `Xoroshiro128`
- `Xoshiro256`
- `Sfc64`
- `RomuTrio`

Example
```luau
local rand = zune.random.new(0) -- defaults to LuauPcg32
local num = rand:nextNumber()

local rand = zune.random.Isaac64.new(0)
local num = rand:nextNumber()
```