### PR TITLE
Remove `tasks` from Scheduler

### DIFF
--- a/src/core/standard/task.zig
+++ b/src/core/standard/task.zig
@@ -131,7 +131,6 @@ fn lua_count(L: *VM.lua.State) !i32 {
             if (item.priority == .User)
                 total += 1;
         }
-        total += scheduler.tasks.items.len;
         total += scheduler.async_tasks;
         L.pushnumber(@floatFromInt(total));
         return 1;
@@ -162,7 +161,7 @@ fn lua_count(L: *VM.lua.State) !i32 {
             },
             't' => {
                 out += 1;
-                L.pushnumber(@floatFromInt(scheduler.tasks.items.len + scheduler.async_tasks));
+                L.pushnumber(@floatFromInt(scheduler.async_tasks));
             },
             else => return L.Zerror("Invalid kind"),
         }

--- a/src/core/standard/testing.zig
+++ b/src/core/standard/testing.zig
@@ -99,13 +99,6 @@ fn testing_droptasks(L: *VM.lua.State) i32 {
         awaiting.virtualDtor(awaiting.data, awaiting.state.value, scheduler);
     }
 
-    var tasksSize = scheduler.tasks.items.len;
-    while (tasksSize > 0) {
-        tasksSize -= 1;
-        const task = scheduler.tasks.swapRemove(tasksSize);
-        task.virtualDtor(task.data, task.state.value, scheduler);
-    }
-
     var sleepingSize = scheduler.sleeping.items.len;
     while (sleepingSize > 0) {
         sleepingSize -= 1;


### PR DESCRIPTION
No zune backend code depends on `tasks` anymore, took a while to get here :smile:.

- Removes legacy `tasks` support.
- Reduces scheduler work.