### PR TITLE
Add Luau Coverage User API & Luau 0.681

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -16,8 +16,8 @@
             .hash = "lz4-0.2.0-OvBcTytgAAC95acrxK1s8UwtlTWR-7J4UvEkgstnvN1p",
         },
         .luau = .{
-            .url = "https://codeload.github.com/Scythe-Technology/zig-luau/tar.gz/5610af2914aeaa21096aabb3d36acef37b2db21b",
-            .hash = "luau-0.4.0+679-uDAGp2aTBgCIYRNECvJX9ziR30gKIxeGpI4GpyT6vtQE",
+            .url = "https://codeload.github.com/Scythe-Technology/zig-luau/tar.gz/745a34b9b3f57c62acad6ccc3e0a9d8c06021410",
+            .hash = "luau-0.4.0+681-uDAGp5-TBgAqEwyQfq7mddeZv2yRfnHv0GQkRu3rarp2",
         },
         .pcre2 = .{
             .url = "https://codeload.github.com/Scythe-Technology/zpcre2/tar.gz/9e6a4e39b585e6ab6b759a949469755625e81418",

--- a/src/types/global/zune.d.luau
+++ b/src/types/global/zune.d.luau
@@ -1350,6 +1350,38 @@ export type LoadOptions = {
     nativeCodeGen: boolean?,
 }
 
+export type CoverageData = {
+    name: string,
+    line: number,
+    depth: number,
+    [number]: number,
+};
+
+export type ParseResult = {
+    errors: {
+        {
+            message: string,
+            location: string,
+        }
+    }
+} | {
+    root: {any},
+    lines: number,
+    commentLocations: {
+        {
+            type: string,
+            location: string,
+        }
+    },
+    hotcomments: {
+        {
+            header: boolean,
+            content: string,
+            location: string,
+        }
+    }
+};
+
 type LuauLib = {
     --[[
         Compiles Luau source code.
@@ -1359,7 +1391,7 @@ type LuauLib = {
         @return `string` The compiled code, or an error.
         @error `CompileError`
     ]]
-    compile: (source: string, options: CompileOptions?) -> string,
+    compile: (source: string, opts: CompileOptions?) -> string,
 
     --[[
         Loads Luau source code.
@@ -1374,7 +1406,12 @@ type LuauLib = {
         @param options The options for the load.
         @return `(...any) -> ...any` The loaded function.
     ]]
-    load: (bytecode: string, options: LoadOptions?) -> ((...any) -> ...any),
+    load: (bytecode: string, opts: LoadOptions?) -> ((...any) -> ...any),
+
+    coverage: (fn: (...any) -> ...any) -> {CoverageData},
+
+    parse: (src: string) -> ParseResult,
+    parseExpr: (src: string) -> ParseResult,
 }
 --[======[ Luau ]======]--
 

--- a/test/standard/luau.test.luau
+++ b/test/standard/luau.test.luau
@@ -205,6 +205,30 @@ describe("Load", function()
     end)
 end)
 
+test("Coverage", function()
+    local bytecode = luau.compile([[
+        local function nothing()
+        end
+        local function bar()
+
+        end
+        local function foo()
+            bar()
+        end
+        foo()
+    ]], {coverage_level = 2});
+
+    local load = luau.load(bytecode, {
+        chunkName = "test",
+    });
+
+    load();
+
+    local coverage = luau.coverage(load);
+
+    print(coverage);
+end)
+
 describe("Parse", function()
     test("Basic", function()
         local input = [[


### PR DESCRIPTION
- Upgrade to luau `0.681`
- Adds coverage api.
```luau
luau.coverage(fn: (...any) -> ...any): {CoverageData}
```