### PR TITLE
Slight changes in thread object dtor and fs watcher

### DIFF
--- a/src/core/standard/fs/lib.zig
+++ b/src/core/standard/fs/lib.zig
@@ -440,7 +440,7 @@ const WatchState = struct {
     mutex: std.Thread.Mutex = .{},
     cond: std.Thread.Condition = .{},
     info: ?Watch.WatchInfo = null,
-    state: std.atomic.Value(LoopState) = .{ .raw = .Alive },
+    state: std.atomic.Value(LoopState) align(std.atomic.cache_line) = .{ .raw = .Alive },
 
     pub const LoopState = enum(u8) { Alive, Terminating, Dead };
 


### PR DESCRIPTION
- Fix(maybe?) the deadlock for the threads dtor happening on CI.
- align atomic state in `WatchState` for cache performance.