### PR TITLE
Disable `check` command

### DIFF
--- a/src/commands/lib.zig
+++ b/src/commands/lib.zig
@@ -41,7 +41,7 @@ pub const CommandMap = initCommands(&.{
     @import("setup.zig").Command,
     @import("repl/lib.zig").Command,
     @import("init.zig").Command,
-    @import("check.zig").Command,
+    // @import("check.zig").Command,
 
     @import("luau.zig").Command,
     @import("help.zig").Command,


### PR DESCRIPTION
Temporarily disable `check` command, relevant to #56

Should look more into this for 0.6.0+ or completely remove this from the codebase.