### PR TITLE
More FFI API

### DIFF
--- a/src/core/standard/ffi.zig
+++ b/src/core/standard/ffi.zig
@@ -246,7 +246,7 @@ const LuaPointer = struct {
         Static,
     };
 
-    pub fn ptrFromBuffer(L: *VM.lua.State) !i32 {
+    pub fn ptrFromAddress(L: *VM.lua.State) !i32 {
         const buf = L.Lcheckbuffer(1);
         if (buf.len < @sizeOf(usize))
             return error.SmallBuffer;
@@ -307,7 +307,7 @@ const LuaPointer = struct {
         return ptr;
     }
 
-    pub fn getRef(L: *VM.lua.State) !i32 {
+    pub fn allocPtr(L: *VM.lua.State) !i32 {
         const ref_ptr = value(L, 1) orelse return error.Failed;
         const allocator = luau.getallocator(L);
 
@@ -2312,8 +2312,8 @@ pub fn loadLib(L: *VM.lua.State) !void {
 
     try L.Zsetfieldfn(-1, "tagName", lua_tagName);
 
-    try L.Zsetfieldfn(-1, "getRef", LuaPointer.getRef);
-    try L.Zsetfieldfn(-1, "createPtr", LuaPointer.ptrFromBuffer);
+    try L.Zsetfieldfn(-1, "ptr", LuaPointer.allocPtr);
+    try L.Zsetfieldfn(-1, "ptrFromAddress", LuaPointer.ptrFromAddress);
 
     try L.Zsetfieldfn(-1, "getLuaState", lua_getLuaState);
 

--- a/src/types/global/zune.d.luau
+++ b/src/types/global/zune.d.luau
@@ -2145,8 +2145,8 @@ type FFILib = {
         pointer: FFIPointerType,
     },
 
-    createPtr: (src: buffer) -> FFIPointer,
-    getRef: (src: FFIPointer) -> FFIPointer,
+    ptr: (src: FFIPointer) -> FFIPointer,
+    ptrFromAddress: (src: buffer) -> FFIPointer,
 
     getLuaState: (mainthread: boolean?) -> FFIPointer,
 

--- a/src/types/global/zune.d.luau
+++ b/src/types/global/zune.d.luau
@@ -2063,6 +2063,10 @@ export type FFILibrary = {
     [string]: (...any) -> any,
 }
 
+declare class FFICompiled
+    function getSymbol(self, symbol: string): FFIPointer
+end
+
 declare class FFIDataType
     function size(self): number
     function alignment(self): number
@@ -2124,6 +2128,15 @@ export type FFIPointer = {
     span: (self: FFIPointer, offset: number?) -> buffer,
 }
 
+type FFICompileOptions = {
+    options: string?,
+    files: {string}?,
+    libraries: {string}?,
+    includes: {string}?,
+    sysincludes: {string}?,
+    symbols: {[string]: string}?,
+}
+
 type FFILib = {
     supported: boolean,
 
@@ -2143,6 +2156,10 @@ type FFILib = {
         float: FFIDataType,
         double: FFIDataType,
         pointer: FFIPointerType,
+    },
+
+    c: {
+        compile: (src: string, opts: FFICompileOptions?) -> FFICompiled,
     },
 
     ptr: (src: FFIPointer) -> FFIPointer,

--- a/test/standard/ffi/init.test.luau
+++ b/test/standard/ffi/init.test.luau
@@ -48,6 +48,9 @@ expect(ffi).toBe(
             double = expect.type("userdata"),
             pointer = expect.type("userdata"),
         }),
+        c = expect.similar({
+            compile = expect.type("function"),
+        }),
     })
 )
 
@@ -1321,5 +1324,54 @@ describe("FFI", function()
 
         expect(L == L2).toBe(true);
         expect(L == GL).toBe(false);
+    end)
+
+    describe("C", function()
+        describe("Compile", function()
+            test("Basic", function()
+                local compiled = ffi.c.compile([[
+                    int hello() {
+                        return 50;
+                    }
+                    int add(int a) {
+                        return a + 5;
+                    }
+                    double add_double(double a) {
+                        return a + 2.5;
+                    }
+                ]]);
+
+                local hellofn = ffi.fn({ returns = ffi.types.i32, args = {} }, compiled:getSymbol("hello"));
+                local addfn = ffi.fn({ returns = ffi.types.i32, args = {ffi.types.i32} }, compiled:getSymbol("add"));
+                local add_doublefn = ffi.fn({ returns = ffi.types.double, args = {ffi.types.double} }, compiled:getSymbol("add_double"));
+
+                expect(hellofn()).toBe(50);
+                expect(addfn(25)).toBe(30);
+                expect(add_doublefn(62.5)).toBe(65);
+            end)
+            test("Complex", function()
+                local compiled = ffi.c.compile((if (process.os == "windows") then "__declspec(dllimport) " else "extern") .. " void blank();\n\nvoid blank2() { blank(); }", {
+                    files = {`./zig-out/lib/{ffi.prefix}sample.{static_suffix}`},
+                });
+
+                local blank2fn = ffi.fn({ returns = ffi.types.void, args = {} }, compiled:getSymbol("blank2"));
+
+                blank2fn();
+            end)
+            test("Error", function()
+                expect(function()
+                    ffi.c.compile([[
+                        double add_double(
+                    ]]);
+                end).toThrow("error: identifier expected");
+                expect(function()
+                    ffi.c.compile([[
+                        double add_double(double a) {
+                            return a + 2.5;
+                        }
+                    ]], { files = {`unknown_nothing`} });
+                end).toThrow("tcc: error: file 'unknown_nothing' not found");
+            end)
+        end)
     end)
 end)

--- a/test/standard/ffi/init.test.luau
+++ b/test/standard/ffi/init.test.luau
@@ -22,8 +22,8 @@ expect(ffi).toBe(
         struct = expect.type("function"),
         closure = expect.type("function"),
         fn = expect.type("function"),
-        createPtr = expect.type("function"),
-        getRef = expect.type("function"),
+        ptr = expect.type("function"),
+        ptrFromAddress = expect.type("function"),
         getLuaState = expect.type("function"),
         alloc = expect.type("function"),
         free = expect.type("function"),
@@ -93,7 +93,7 @@ describe("FFI", function()
         test("Span From Pointer", function()
             local src = ffi.dupe(buffer.fromstring("terminated string\0")):release();
 
-            local ptr = ffi.getRef(src):release();
+            local ptr = ffi.ptr(src):release();
             local unknown = ptr:readPtr():release();
 
             local buf = unknown:span(0);
@@ -143,14 +143,14 @@ describe("FFI", function()
 
             local mem = ffi.dupe(src);
             mem:release();
-            local ptr = ffi.getRef(mem):release():readPtr();
-            local ptr2 = ffi.getRef(mem):release():readPtr();
+            local ptr = ffi.ptr(mem):release():readPtr();
+            local ptr2 = ffi.ptr(mem):release():readPtr();
 
             expect(ptr == ptr2).toBe(true);
 
             expect(mem:readi32()).toBe(42);
 
-            local null_ptr = ffi.createPtr(buffer.create(ffi.types.pointer:size()));
+            local null_ptr = ffi.ptrFromAddress(buffer.create(ffi.types.pointer:size()));
 
             expect(null_ptr:isNull()).toBe(true);
             expect(null_ptr == ptr).toBe(false);
@@ -199,15 +199,15 @@ describe("FFI", function()
 
         test("Static Offset", function()
             local address = buffer.create(ffi.types.pointer:size());
-            local base = ffi.createPtr(address);
+            local base = ffi.ptrFromAddress(address);
             
-            expect(base == ffi.createPtr(address)).toBe(true);
+            expect(base == ffi.ptrFromAddress(address)).toBe(true);
             expect(base:isNull()).toBe(true);
 
             for i = 1, 3 do
                 local ptr = base:offset(i);
                 buffer.writeu8(address, 0, i);
-                local located_ptr = ffi.createPtr(address);
+                local located_ptr = ffi.ptrFromAddress(address);
                 expect(ptr == base).toBe(false);
                 expect(ptr == located_ptr).toBe(true);
                 expect(ffi.len(ptr)).toBe(nil);
@@ -646,7 +646,7 @@ describe("FFI", function()
                 local out = ffi.alloc(ffi.types.i32:size());
                 out:release();
 
-                local ptr = ffi.getRef(out):release();
+                local ptr = ffi.ptr(out):release();
 
                 lib.add_ptr_ptr(ptr, 1);
                 
@@ -665,7 +665,7 @@ describe("FFI", function()
                 local out = ffi.alloc(ffi.types.i32:size());
                 out:release();
 
-                local ptr = ffi.getRef(out):release();
+                local ptr = ffi.ptr(out):release();
 
                 add_ptr_ptr(ptr, 1);
                 
@@ -1090,12 +1090,12 @@ describe("FFI", function()
             test("Library Fn", function()
                 expect(lib.check_nullptr(nil)).toBe(1);
             
-                local null_ptr = ffi.createPtr(buffer.create(ffi.types.pointer:size()));
+                local null_ptr = ffi.ptrFromAddress(buffer.create(ffi.types.pointer:size()));
                 expect(lib.check_nullptr(null_ptr)).toBe(1);
 
                 local dummy_value = ffi.dupe(buffer.create(0));
                 dummy_value:release();
-                local ptr = ffi.getRef(dummy_value):release();
+                local ptr = ffi.ptr(dummy_value):release();
                 expect(lib.check_nullptr(ptr)).toBe(0);
                 expect(lib.check_nullptr("")).toBe(0);
             end)
@@ -1104,12 +1104,12 @@ describe("FFI", function()
 
                 expect(check_nullptr(nil)).toBe(1);
             
-                local null_ptr = ffi.createPtr(buffer.create(ffi.types.pointer:size()));
+                local null_ptr = ffi.ptrFromAddress(buffer.create(ffi.types.pointer:size()));
                 expect(check_nullptr(null_ptr)).toBe(1);
 
                 local dummy_value = ffi.dupe(buffer.create(0));
                 dummy_value:release();
-                local ptr = ffi.getRef(dummy_value):release();
+                local ptr = ffi.ptr(dummy_value):release();
                 expect(check_nullptr(ptr)).toBe(0);
                 expect(check_nullptr("")).toBe(0);
             end)
@@ -1205,13 +1205,13 @@ describe("FFI", function()
                 buffer.writei32(temp, 12, -10);
                 ffi.copy(mem, 0, temp, 0, 24);
 
-                ffi.copy(block_address, 0, ffi.getRef(mem):release(), 0, ffi.types.pointer:size());
+                ffi.copy(block_address, 0, ffi.ptr(mem):release(), 0, ffi.types.pointer:size());
 
                 mem:drop();
             end)
 
             test("Leaky Unknown Block, Free", function()
-                local mem = ffi.createPtr(block_address);
+                local mem = ffi.ptrFromAddress(block_address);
                 expect(mem:isNull()).toBe(false);
                 expect(ffi.len(mem)).toBe(nil); -- unknown size
                 


### PR DESCRIPTION
- Renamed `getRef` to `ptr`.
- Renamed `createPtr` to `ptrFromAddress`.
- Added `ffi.c.compile`.