### PR TITLE
Fix runtime bugs & upgrade `Luau`

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -16,8 +16,8 @@
             .hash = "lz4-0.2.0-OvBcTytgAAC95acrxK1s8UwtlTWR-7J4UvEkgstnvN1p",
         },
         .luau = .{
-            .url = "https://codeload.github.com/Scythe-Technology/zig-luau/tar.gz/6e6a506d565e31482bd2d8986b6c3ccd94a0cb34",
-            .hash = "luau-0.0.0+684-uDAGp3SkCQAIGBKTJ9Q0milzmJZjD3aKajmH16YMQcLP",
+            .url = "https://codeload.github.com/Scythe-Technology/zig-luau/tar.gz/709ec5b20d0a48e2aa17cf009f514eb73ba256a7",
+            .hash = "luau-0.0.0+684-uDAGp-OxCQAAPW5rKCGu8rh34hYuSAgGghfIYvwzEX1f",
         },
         .pcre2 = .{
             .url = "https://codeload.github.com/Scythe-Technology/zpcre2/tar.gz/9e6a4e39b585e6ab6b759a949469755625e81418",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -16,8 +16,8 @@
             .hash = "lz4-0.2.0-OvBcTytgAAC95acrxK1s8UwtlTWR-7J4UvEkgstnvN1p",
         },
         .luau = .{
-            .url = "https://codeload.github.com/Scythe-Technology/zig-luau/tar.gz/a6bae9c6f456b79b223452c1c152d59339e6e8e1",
-            .hash = "luau-0.0.0+685-uDAGp5uxCQD9nLY5oQpKufQBVw5idzJav8dvre9E5PFP",
+            .url = "https://codeload.github.com/Scythe-Technology/zig-luau/tar.gz/54fbd625ac871ade8eda1509abd57b3fa11af6e8",
+            .hash = "luau-0.0.0+685-uDAGp46yCQArh83ugAT27H3Uqkx45BekXUiwjaFIp_Ox",
         },
         .pcre2 = .{
             .url = "https://codeload.github.com/Scythe-Technology/zpcre2/tar.gz/9e6a4e39b585e6ab6b759a949469755625e81418",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -16,8 +16,8 @@
             .hash = "lz4-0.2.0-OvBcTytgAAC95acrxK1s8UwtlTWR-7J4UvEkgstnvN1p",
         },
         .luau = .{
-            .url = "https://codeload.github.com/Scythe-Technology/zig-luau/tar.gz/709ec5b20d0a48e2aa17cf009f514eb73ba256a7",
-            .hash = "luau-0.0.0+684-uDAGp-OxCQAAPW5rKCGu8rh34hYuSAgGghfIYvwzEX1f",
+            .url = "https://codeload.github.com/Scythe-Technology/zig-luau/tar.gz/a6bae9c6f456b79b223452c1c152d59339e6e8e1",
+            .hash = "luau-0.0.0+685-uDAGp5uxCQD9nLY5oQpKufQBVw5idzJav8dvre9E5PFP",
         },
         .pcre2 = .{
             .url = "https://codeload.github.com/Scythe-Technology/zpcre2/tar.gz/9e6a4e39b585e6ab6b759a949469755625e81418",


### PR DESCRIPTION
- Fixes corruption on standalone gco blocks (upgrading `zig-luau`).
- Luau `0.685`.