### PR TITLE
Luau Parser Fixes

### DIFF
--- a/src/core/standard/luau.zig
+++ b/src/core/standard/luau.zig
@@ -1720,7 +1720,7 @@ const AstSerializer = struct {
 
             if (typeNode.is(.type_optional)) {
                 try self.serializeToken(typeNode.location.begin, "?", 1);
-                try self.L.Zsetfield(-2, "tag", "optional");
+                try self.L.Zsetfield(-1, "tag", "optional");
                 try self.L.rawsetfield(-2, "node");
             } else {
                 try typeNode.visit(self);

--- a/src/core/standard/luau.zig
+++ b/src/core/standard/luau.zig
@@ -716,10 +716,11 @@ const AstSerializer = struct {
             try self.L.rawsetfield(-2, "openGenerics");
 
             const commas = cstNode.genericsCommaPositions;
-            try self.serializePunctuated(node.generics, commas.slice(), ",");
+            const slice = commas.slice();
+            try self.serializePunctuated(node.generics, slice, ",");
             try self.L.rawsetfield(-2, "generics");
 
-            try self.serializePunctuated(node.genericPacks, commas.slice()[node.generics.size..], ",");
+            try self.serializePunctuated(node.genericPacks, if (slice.len < node.generics.size) slice else slice[node.generics.size..], ",");
             try self.L.rawsetfield(-2, "genericPacks");
 
             try self.serializeToken(cstNode.closeGenericsPosition, ">", null);
@@ -1357,10 +1358,11 @@ const AstSerializer = struct {
             try self.L.rawsetfield(-2, "openGenerics");
 
             const commas = cstNode.genericsCommaPositions;
-            try self.serializePunctuated(node.generics, commas.slice(), ",");
+            const slice = commas.slice();
+            try self.serializePunctuated(node.generics, slice, ",");
             try self.L.rawsetfield(-2, "generics");
 
-            try self.serializePunctuated(node.genericPacks, commas.slice()[node.generics.size..], ",");
+            try self.serializePunctuated(node.genericPacks, if (slice.len < node.generics.size) slice else slice[node.generics.size..], ",");
             try self.L.rawsetfield(-2, "genericPacks");
 
             try self.serializeToken(cstNode.genericsClosePosition, ">", null);
@@ -1615,10 +1617,11 @@ const AstSerializer = struct {
             try self.L.rawsetfield(-2, "openGenerics");
 
             const commas = cstNode.genericsCommaPositions;
-            try self.serializePunctuated(node.generics, commas.slice(), ",");
+            const slice = commas.slice();
+            try self.serializePunctuated(node.generics, slice, ",");
             try self.L.rawsetfield(-2, "generics");
 
-            try self.serializePunctuated(node.genericPacks, commas.slice()[node.generics.size..], ",");
+            try self.serializePunctuated(node.genericPacks, if (slice.len < node.generics.size) slice else slice[node.generics.size..], ",");
             try self.L.rawsetfield(-2, "genericPacks");
 
             try self.serializeToken(cstNode.closeGenericsPosition, ">", null);
@@ -1821,7 +1824,7 @@ const AstSerializer = struct {
         try self.L.Zsetfield(-1, "tag", "variadic");
         try self.L.Zsetfield(-1, "location", node.location);
 
-        if (forVarArg) {
+        if (!forVarArg) {
             try self.serializeToken(node.location.begin, "...", null);
             try self.L.rawsetfield(-2, "ellipsis");
         }

--- a/src/core/standard/luau.zig
+++ b/src/core/standard/luau.zig
@@ -561,6 +561,16 @@ const AstSerializer = struct {
 
         try self.L.Zsetfield(-1, "tag", "group");
         try self.L.Zsetfield(-1, "location", node.location);
+
+        try self.serializeToken(node.location.begin, "(", null);
+        try self.L.rawsetfield(-2, "openParens");
+
+        try node.expr.visit(self);
+        try self.L.rawsetfield(-2, "expression");
+
+        try self.serializeToken(.{ .line = node.location.end.line, .column = node.location.end.column - 1 }, ")", null);
+        try self.L.rawsetfield(-2, "closeParens");
+
         return false;
     }
     pub fn visitExprConstantNil(self: *@This(), node: *Ast.ExprConstantNil) !bool {

--- a/src/core/standard/luau.zig
+++ b/src/core/standard/luau.zig
@@ -1550,7 +1550,7 @@ const AstSerializer = struct {
                 try self.L.rawsetfield(-2, "colon");
 
                 try node.indexer.?.resultType.visit(self);
-                try self.L.rawsetfield(-2, "type");
+                try self.L.rawsetfield(-2, "value");
 
                 if (item.separator.to()) |separator| {
                     try self.serializeToken(item.separatorPosition.to().?, if (separator == .comma) "," else ";", null);


### PR DESCRIPTION
- Rename field `type` for AstTypeTable indexer to `value`
- Fixes serializing AstTypePackVariadic type.
- Fixes genericPacks split.
- Fixes missing tag value for optional AstTypeUnion.