### PR TITLE
Scheduler Fixes

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -44,8 +44,8 @@
             .hash = "tinycc-0.0.2-T6dU8_3FAAAVHDvXDJaSfS1srHGOuUmdXCt2MWKEjlBh",
         },
         .libxev = .{
-            .url = "https://codeload.github.com/Scythe-Technology/libxev/tar.gz/2e02b73c172e5aee0f2db253d3f560a16bce9e33",
-            .hash = "libxev-0.0.0-Gdacvif_CwD7G_gPyU9qwbdu1Q48MaldtQ1TlOOF-uga",
+            .url = "https://codeload.github.com/Scythe-Technology/libxev/tar.gz/2bd966b1450a7e7b020b350109e2442bb5c88685",
+            .hash = "libxev-0.0.0-Gdacvu7_CwCywFuNf767Zh7HkUB3wjDKAIUbDbeWl6Sg",
         },
         .tls = .{
             .url = "https://codeload.github.com/ianic/tls.zig/tar.gz/7428921d2d5c397324d3e0343d7d8c90c2d35d31",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -44,8 +44,8 @@
             .hash = "tinycc-0.0.2-T6dU8_3FAAAVHDvXDJaSfS1srHGOuUmdXCt2MWKEjlBh",
         },
         .libxev = .{
-            .url = "https://codeload.github.com/Scythe-Technology/libxev/tar.gz/2bd966b1450a7e7b020b350109e2442bb5c88685",
-            .hash = "libxev-0.0.0-Gdacvu7_CwCywFuNf767Zh7HkUB3wjDKAIUbDbeWl6Sg",
+            .url = "https://codeload.github.com/Scythe-Technology/libxev/tar.gz/dfc90643e5076cf727d9401aff9c886ab6dec78d",
+            .hash = "libxev-0.0.0-GdacviIFDAAFRWY3D6x4C8KvhFWf-_tHaulbAkz_MTmg",
         },
         .tls = .{
             .url = "https://codeload.github.com/ianic/tls.zig/tar.gz/7428921d2d5c397324d3e0343d7d8c90c2d35d31",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -44,8 +44,8 @@
             .hash = "tinycc-0.0.2-T6dU8_3FAAAVHDvXDJaSfS1srHGOuUmdXCt2MWKEjlBh",
         },
         .libxev = .{
-            .url = "https://codeload.github.com/Scythe-Technology/libxev/tar.gz/2ae9806befa79a8d3818506ef75d1d9156c58aae",
-            .hash = "libxev-0.0.0-Gdacvun-CwCp6yqO0FZW1TFwUscj5Vwb-lzY7ILHiVyx",
+            .url = "https://codeload.github.com/Scythe-Technology/libxev/tar.gz/2e02b73c172e5aee0f2db253d3f560a16bce9e33",
+            .hash = "libxev-0.0.0-Gdacvif_CwD7G_gPyU9qwbdu1Q48MaldtQ1TlOOF-uga",
         },
         .tls = .{
             .url = "https://codeload.github.com/ianic/tls.zig/tar.gz/7428921d2d5c397324d3e0343d7d8c90c2d35d31",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -44,8 +44,8 @@
             .hash = "tinycc-0.0.2-T6dU8_3FAAAVHDvXDJaSfS1srHGOuUmdXCt2MWKEjlBh",
         },
         .libxev = .{
-            .url = "https://codeload.github.com/Scythe-Technology/libxev/tar.gz/7bf6dbed9945b16127784b0c3c4b61a26996c0ad",
-            .hash = "libxev-0.0.0-Gdacvq37CwBxqcuheDOZlHMrwRtNAqSLz6oTH98D04W0",
+            .url = "https://codeload.github.com/Scythe-Technology/libxev/tar.gz/2ae9806befa79a8d3818506ef75d1d9156c58aae",
+            .hash = "libxev-0.0.0-Gdacvun-CwCp6yqO0FZW1TFwUscj5Vwb-lzY7ILHiVyx",
         },
         .tls = .{
             .url = "https://codeload.github.com/ianic/tls.zig/tar.gz/7428921d2d5c397324d3e0343d7d8c90c2d35d31",

--- a/src/core/runtime/scheduler.zig
+++ b/src/core/runtime/scheduler.zig
@@ -261,7 +261,6 @@ timer: xev.Dynamic.Timer,
 loop: xev.Dynamic.Loop,
 @"async": xev.Dynamic.Async,
 pools: Pool,
-async_tasks: usize = 0,
 now_clock: f64 = 0,
 
 running: bool = false,
@@ -390,7 +389,6 @@ pub fn completeAsync(
     self: *Scheduler,
     data: anytype,
 ) void {
-    defer self.async_tasks -= 1;
     self.allocator.destroy(data);
 }
 
@@ -399,7 +397,6 @@ pub fn createAsyncCtx(
     comptime T: type,
 ) std.mem.Allocator.Error!*T {
     const ptr = try self.allocator.create(T);
-    defer self.async_tasks += 1;
     return ptr;
 }
 
@@ -542,7 +539,7 @@ inline fn hasPendingWork(self: *Scheduler) bool {
     return self.sleeping.items.len > 0 or
         self.deferred.len > 0 or
         self.awaits.items.len > 0 or
-        self.async_tasks > 0 or
+        self.loop.countPending() > 0 or
         self.sync.hasPending();
 }
 

--- a/src/core/standard/net/http/server/lib.zig
+++ b/src/core/standard/net/http/server/lib.zig
@@ -92,8 +92,6 @@ fn __dtor(L: *VM.lua.State, self: *Self) void {
     defer self.arena.deinit();
 
     self.callbacks.derefAll(L);
-
-    self.scheduler.async_tasks -= 1;
 }
 
 pub fn emitError(
@@ -362,8 +360,6 @@ pub fn lua_serve(L: *VM.lua.State) !i32 {
         L.pop(1);
     }
     L.pop(1);
-
-    scheduler.async_tasks += 1;
 
     const address_str = serve_info.address orelse "127.0.0.1";
 

--- a/src/core/standard/task.zig
+++ b/src/core/standard/task.zig
@@ -133,7 +133,6 @@ fn lua_count(L: *VM.lua.State) !i32 {
             if (item.priority == .User)
                 total += 1;
         }
-        total += scheduler.async_tasks;
         L.pushnumber(@floatFromInt(total));
         return 1;
     };
@@ -163,7 +162,7 @@ fn lua_count(L: *VM.lua.State) !i32 {
             },
             't' => {
                 out += 1;
-                L.pushnumber(@floatFromInt(scheduler.async_tasks));
+                L.pushnumber(@floatFromInt(scheduler.loop.countPending()));
             },
             else => return L.Zerror("Invalid kind"),
         }

--- a/src/core/standard/task.zig
+++ b/src/core/standard/task.zig
@@ -133,6 +133,7 @@ fn lua_count(L: *VM.lua.State) !i32 {
             if (item.priority == .User)
                 total += 1;
         }
+        total += scheduler.loop.countPending();
         L.pushnumber(@floatFromInt(total));
         return 1;
     };

--- a/src/core/standard/task.zig
+++ b/src/core/standard/task.zig
@@ -133,7 +133,7 @@ fn lua_count(L: *VM.lua.State) !i32 {
             if (item.priority == .User)
                 total += 1;
         }
-        total += scheduler.loop.countPending();
+        total += scheduler.loop.countPending(.{ .timers = false });
         L.pushnumber(@floatFromInt(total));
         return 1;
     };
@@ -163,7 +163,7 @@ fn lua_count(L: *VM.lua.State) !i32 {
             },
             't' => {
                 out += 1;
-                L.pushnumber(@floatFromInt(scheduler.loop.countPending()));
+                L.pushnumber(@floatFromInt(scheduler.loop.countPending(.{ .timers = false })));
             },
             else => return L.Zerror("Invalid kind"),
         }


### PR DESCRIPTION
- Fixes `websocket`.
- Reduce thread holdups on arm64 and riscv64 builds while using thread library.
- Reduce Scheduler Size by 4-8 bytes.
- Include async tasks in `task.count` total call.