### PR TITLE
Backend fixes

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -4,12 +4,12 @@
     .minimum_zig_version = "0.14.0",
     .dependencies = .{
         .luau = .{
-            .url = "https://codeload.github.com/Scythe-Technology/zig-luau/tar.gz/f32a8c357625f97e3f1d0455fbf3ca67d96bf3cf",
-            .hash = "luau-0.0.0+689-uDAGp2DBCQDuZFXvgRLeDoOS5dJfEzLtIkSyxKVEPWQS",
+            .url = "https://codeload.github.com/Scythe-Technology/zig-luau/tar.gz/ff07eacd43f926b6744b8ffba132a14c9235ecd7",
+            .hash = "luau-0.0.0+690-uDAGp4HBCQDnf0mIhjTQ03dWM3U7ZxTnb4cHtVERwmoN",
         },
         .libxev = .{
-            .url = "https://codeload.github.com/Scythe-Technology/libxev/tar.gz/0dbc59ceab3104be0c72ece9253708047c964846",
-            .hash = "libxev-0.0.0-Gdacvg0iDABTtYmMWrNAk6zKtbcAowsibVDU_VX5lQX5",
+            .url = "https://codeload.github.com/Scythe-Technology/libxev/tar.gz/923fd685b5d23049d6a2ceea0c73eb57235212a9",
+            .hash = "libxev-0.0.0-GdacvjwjDABDtdJnwlFyNd_Ti23ysHQteZVebf1aHXGE",
         },
         .json = .{
             .url = "https://codeload.github.com/Scythe-Technology/zig-json/tar.gz/bfa3d87788301b0df3b05b29f6e323f91bf3abbe",
@@ -48,8 +48,8 @@
             .hash = "tinycc-0.0.3-T6dU8yTKAAAQ0w4V898cCL8RwoCyFdW1Z_THkasfSbsU",
         },
         .tls = .{
-            .url = "https://codeload.github.com/ianic/tls.zig/tar.gz/602f05bd84d819d487a6e22dd1463e907f7992ab",
-            .hash = "tls-0.1.0-ER2e0sR3BQAaKutV0MShEsWhgG5NkNc04OTCEwHUson3",
+            .url = "https://codeload.github.com/ianic/tls.zig/tar.gz/fd11fcfa77628bc2fb9de7fd1fecfe89339c93fc",
+            .hash = "tls-0.1.0-ER2e0mRIBQCvHQz8kf9k3xHQDwz4WH71ht44JoVycYmL",
         },
     },
     .paths = .{""},

--- a/src/core/objects/process/Child.zig
+++ b/src/core/objects/process/Child.zig
@@ -179,35 +179,35 @@ pub const __namecall = MethodMap.CreateNamecallMap(Child, TAG_PROCESS_CHILD, .{
     .{ "wait", lua_wait },
 });
 
-pub const IndexMap = std.StaticStringMap(enum {
-    Stdin,
-    Stdout,
-    Stderr,
-}).initComptime(.{
-    .{ "stdin", .Stdin },
-    .{ "stdout", .Stdout },
-    .{ "stderr", .Stderr },
-});
-
 pub fn __index(L: *VM.lua.State) !i32 {
     try L.Zchecktype(1, .Userdata);
     const self = L.touserdatatagged(Child, 1, TAG_PROCESS_CHILD) orelse return L.Zerror("invalid userdata");
     const index = L.Lcheckstring(2);
 
-    switch (IndexMap.get(index) orelse return L.Zerrorf("unknown index: {s}", .{index})) {
-        .Stdin => {
+    const Map = std.StaticStringMap(enum {
+        stdin,
+        stdout,
+        stderr,
+    }).initComptime(.{
+        .{ "stdin", .stdin },
+        .{ "stdout", .stdout },
+        .{ "stderr", .stderr },
+    });
+
+    switch (Map.get(index) orelse return L.Zerrorf("unknown index: {s}", .{index})) {
+        .stdin => {
             if (self.stdin_file.push(L))
                 return 1;
             L.pushnil();
             return 1;
         },
-        .Stdout => {
+        .stdout => {
             if (self.stdout_file.push(L))
                 return 1;
             L.pushnil();
             return 1;
         },
-        .Stderr => {
+        .stderr => {
             if (self.stderr_file.push(L))
                 return 1;
             L.pushnil();

--- a/src/core/runtime/engine.zig
+++ b/src/core/runtime/engine.zig
@@ -330,7 +330,7 @@ pub fn logDetailedError(L: *VM.lua.State) !void {
         if (b.mode.compiled == .release)
             return;
 
-    var largest_line: usize = 0;
+    var largest_line: usize = 1;
     for (list.items) |info| {
         if (info.current_line) |line|
             largest_line = @max(largest_line, @as(usize, @intCast(line)));

--- a/src/core/standard/luau.zig
+++ b/src/core/standard/luau.zig
@@ -34,7 +34,7 @@ fn lua_compile(L: *VM.lua.State) !i32 {
             return L.Zerror("invalid debug level");
 
         compileOpts.optimizationLevel = opts.optimization_level orelse compileOpts.optimizationLevel;
-        if (compileOpts.optimizationLevel < 0 or compileOpts.optimizationLevel > 3)
+        if (compileOpts.optimizationLevel < 0 or compileOpts.optimizationLevel > 2)
             return L.Zerror("invalid optimization level");
 
         compileOpts.coverageLevel = opts.coverage_level orelse compileOpts.coverageLevel;

--- a/src/core/standard/net/http/client/lib.zig
+++ b/src/core/standard/net/http/client/lib.zig
@@ -690,7 +690,7 @@ pub fn lua_request(L: *VM.lua.State) !i32 {
     var payload: ?[]const u8 = null;
     var max_body_size: ?usize = null;
     var max_header_size: ?usize = null;
-    var max_header_count: ?u32 = null;
+    var max_headers: ?u32 = null;
 
     var headers: std.ArrayListUnmanaged(u8) = .empty;
     defer headers.deinit(allocator);
@@ -750,8 +750,8 @@ pub fn lua_request(L: *VM.lua.State) !i32 {
             max_header_size = @min(size, LuaHelper.MAX_LUAU_SIZE);
         L.pop(1);
 
-        if (try L.Zcheckfield(?u16, 2, "max_header_count")) |size|
-            max_header_count = size;
+        if (try L.Zcheckfield(?u16, 2, "max_headers")) |size|
+            max_headers = size;
         L.pop(1);
 
         if (try L.Zcheckfield(?[]const u8, 2, "method")) |method_str| blk: {
@@ -861,7 +861,7 @@ pub fn lua_request(L: *VM.lua.State) !i32 {
     }
 
     const self = try allocator.create(Self);
-    var parser: Response.Parser = .init(allocator, max_header_count orelse 100);
+    var parser: Response.Parser = .init(allocator, max_headers orelse 100);
     if (max_body_size) |size|
         parser.max_body_size = size;
     if (max_header_size) |size|

--- a/src/core/standard/net/http/server/lib.zig
+++ b/src/core/standard/net/http/server/lib.zig
@@ -125,7 +125,7 @@ pub fn emitError(
 pub fn onAccept(
     ud: ?*Self,
     loop: *xev.Loop,
-    _: *xev.Completion,
+    c: *xev.Completion,
     r: xev.AcceptError!xev.TCP,
 ) xev.CallbackAction {
     const self = ud orelse unreachable;
@@ -134,7 +134,7 @@ pub fn onAccept(
     switch (self.state.stage) {
         .shutdown => {
             self.state.listening = false;
-            self.continueShutdown(loop, &self.close_completion);
+            self.continueShutdown(loop, c);
             return .disarm;
         },
         .accepting => {},

--- a/src/core/standard/serde/toml.zig
+++ b/src/core/standard/serde/toml.zig
@@ -795,6 +795,9 @@ pub fn lua_encode(L: *VM.lua.State) !i32 {
     try L.Zchecktype(1, .Table);
     const allocator = luau.getallocator(L);
 
+    if (L.gettop() != 1)
+        L.settop(1);
+
     var allocating: std.Io.Writer.Allocating = .init(allocator);
     defer allocating.deinit();
 

--- a/src/core/standard/serde/yaml.zig
+++ b/src/core/standard/serde/yaml.zig
@@ -97,6 +97,9 @@ fn encodeValue(L: *VM.lua.State, allocator: std.mem.Allocator, tracked: *std.Aut
 pub fn lua_encode(L: *VM.lua.State) !i32 {
     const allocator = luau.getallocator(L);
 
+    if (L.gettop() != 1)
+        L.settop(1);
+
     var arena = std.heap.ArenaAllocator.init(allocator);
     defer arena.deinit();
 


### PR DESCRIPTION
- Upgrades to Luau `0.690`.
- Added `max_body_size`, `max_header_size`, `max_headers` options to http client.
- Fixes datetime parser unable to parse RFC 2822 date format properly and added ±HHMM offset support.
- Fixes server crash when stopping while using `epoll` backend.
- Fixes unable to read from `io.stdin` while using `epoll` after stopping server.
- Fixes error preview line failing log10 without initial largest size.
- Fixes toml and yaml serde not encoding the first parameter.