### PR TITLE
Optimize general debug and fixes

### DIFF
--- a/src/commands/execution.zig
+++ b/src/commands/execution.zig
@@ -194,7 +194,6 @@ fn cmdRun(allocator: std.mem.Allocator, args: []const []const u8) !void {
     try ML.Lsandboxthread();
 
     try Engine.setLuaFileContext(ML, .{
-        .source = file_content,
         .main = true,
     });
 
@@ -351,7 +350,6 @@ fn cmdTest(allocator: std.mem.Allocator, args: []const []const u8) !void {
     try ML.Lsandboxthread();
 
     try Engine.setLuaFileContext(ML, .{
-        .source = file_content,
         .main = true,
     });
 
@@ -406,7 +404,6 @@ fn cmdEval(allocator: std.mem.Allocator, args: []const []const u8) !void {
     try ML.Lsandboxthread();
 
     try Engine.setLuaFileContext(ML, .{
-        .source = file_content,
         .main = true,
     });
 
@@ -555,7 +552,6 @@ fn cmdDebug(allocator: std.mem.Allocator, args: []const []const u8) !void {
         try ML.Lsandboxthread();
 
         try Engine.setLuaFileContext(ML, .{
-            .source = file_content,
             .main = true,
         });
 

--- a/src/commands/repl/lib.zig
+++ b/src/commands/repl/lib.zig
@@ -56,7 +56,6 @@ fn Execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
     try Zune.openZune(L, args, .{});
 
     try Engine.setLuaFileContext(L, .{
-        .source = "",
         .main = true,
     });
 

--- a/src/core/lua/testing_lib.luau
+++ b/src/core/lua/testing_lib.luau
@@ -17,7 +17,6 @@ type TestInfo = {
 
 type FileContext = {
     name: string,
-    source: string,
 };
 
 type StackTraceInfo = {
@@ -136,13 +135,13 @@ local function runTest(fn: () -> (), info: TestInfo)
                 if (l < 0) then
                     continue;
                 end
-                local context = getfenv(f) :: {[string]: any};
-                local file = context._FILE;
-                if (type(file) ~= "table") then
+                local env = getfenv(f);
+                if (env == GLOBAL) then
                     continue;
                 end
-                local copy = table.clone(file);
-                copy.name = s;
+                local copy = {
+                    name = s,
+                };
                 table.insert(
                     stacktrace,
                     writeStackTrace(copy :: any, ln::string, l, tostring(f :: any))
@@ -256,32 +255,36 @@ local function runTest(fn: () -> (), info: TestInfo)
         print(`{RED}error{RESET}: {err}{RESET}`);
 
         for stack, v in stacktrace do
-            local contents = v.file.source;
-            local lineNumber = v.line;
+            local nameHasValue = nonEmptyString(v.name);
+            if (v.file.name:find("[string \"", 1, true)) then
+                print(`{BOLD}{UNDERLINE}{v.file.name}:{v.line}:{RESET} {DIM}{v.address:sub(11)}{nameHasValue and ` called {v.name}` or ""}{RESET}`);
+                continue;
+            end
+            print(`{BOLD}{UNDERLINE}{v.file.name}:{v.line}:{RESET} {DIM}{v.address:sub(11)}{nameHasValue and ` called {v.name}` or ""}{RESET}`);
+            local contents = zune.fs.readFileSync(v.file.name);
+            local line_number = v.line;
             local lines = contents:split("\n");
             local possible_lines = {}
             for i = -1, 1 do
-                table.insert(possible_lines, #tostring(lineNumber + i))
+                table.insert(possible_lines, #tostring(line_number + i))
             end
             local bigLineLen = math.max(unpack(possible_lines))
     
             local line = lines[v.line];
+            if (not line) then
+                continue;
+            end
             local safeLine = line:gsub("\t", "    ");
             local indent : number = #(string.match(safeLine, "^(%s*)") or "");
-            local column = #(string.match(line, "^(%s*)") or "");
-            local nameHasValue = nonEmptyString(v.name);
-            if (nameHasValue and v.name) then
+            if (nameHasValue) then
                 local start = safeLine:find(v.name, 1, true);
                 if (start) then
                     local subColumn = line:find(v.name, 1, true);
                     if (subColumn) then
-                        column = subColumn;
                         indent = (start - 1) or indent;
                     end
                 end
             end
-
-            print(`{BOLD}{UNDERLINE}{v.file.name}:{v.line}:{column}:{RESET} {DIM}{v.address:sub(11)}{nameHasValue and ` called {v.name}` or ""}{RESET}`);
             printPreviewLine(lines, v.line - 1, bigLineLen, true);
             printPreviewLine(lines, v.line, bigLineLen, false);
             printPreviewLine(lines, v.line + 1, bigLineLen, true);

--- a/src/core/resolvers/require.zig
+++ b/src/core/resolvers/require.zig
@@ -334,7 +334,6 @@ pub fn zune_require(L: *VM.lua.State) !i32 {
         try ML.Lsandboxthread();
 
         try Engine.setLuaFileContext(ML, .{
-            .source = if (Zune.STATE.BUNDLE == null or Zune.STATE.BUNDLE.?.mode.compiled == .debug) file_content else null,
             .main = false,
         });
 

--- a/src/core/standard/thread.zig
+++ b/src/core/standard/thread.zig
@@ -565,7 +565,6 @@ fn lua_fromModule(L: *VM.lua.State) !i32 {
     const ML = try createThread(allocator, L);
 
     try Zune.Runtime.Engine.setLuaFileContext(ML, .{
-        .source = if (Zune.STATE.BUNDLE == null or Zune.STATE.BUNDLE.?.mode.compiled == .debug) file_content else null,
         .main = false,
     });
 
@@ -597,7 +596,6 @@ fn lua_fromBytecode(L: *VM.lua.State) !i32 {
     const ML = try createThread(allocator, L);
 
     try Zune.Runtime.Engine.setLuaFileContext(ML, .{
-        .source = null,
         .main = true,
     });
 

--- a/src/core/utils/testrunner.zig
+++ b/src/core/utils/testrunner.zig
@@ -82,7 +82,6 @@ pub fn runTest(comptime testFile: TestFile, args: []const []const u8, comptime o
     try ML.Lsandboxthread();
 
     try Engine.setLuaFileContext(ML, .{
-        .source = content,
         .main = true,
     });
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -419,7 +419,6 @@ pub fn main() !void {
         try ML.Lsandboxthread();
 
         try Runtime.Engine.setLuaFileContext(ML, .{
-            .source = if (b.mode.compiled == .debug) b.entry.data else null,
             .main = true,
         });
 

--- a/src/types/global/zune.d.json
+++ b/src/types/global/zune.d.json
@@ -3,7 +3,6 @@
     "code_sample": "",
     "documentation": "",
     "keys": {
-      "source": "@roblox/global/_FILE.source",
       "main": "@roblox/global/_FILE.main"
     }
   },

--- a/src/types/global/zune.d.luau
+++ b/src/types/global/zune.d.luau
@@ -1634,7 +1634,6 @@ export type _zune_task = {
     count: (() -> number) & ((kinds: string) -> ...number), 
 }
 declare _FILE: {
-    source: string?,
     main: boolean, 
 }
 declare zune: {


### PR DESCRIPTION
Including `source` used up unnecessary amount of data & some slowdowns, better to remove it than to keep it.

- Update types and docs.
- Dynamically read files on error traces.
- Remove `source` from `_FILE` global.
- Remove column in error traces testing library.
- Fixes no error traces when lua function errors in http server request callback.