### PR TITLE
IPC Client Debugger

### DIFF
--- a/src/commands/repl/lib.zig
+++ b/src/commands/repl/lib.zig
@@ -95,7 +95,7 @@ fn Execute(allocator: std.mem.Allocator, args: []const []const u8) !void {
 
     switch (L.rawgetfield(luau.VM.lua.GLOBALSINDEX, "_VERSION")) {
         .String => try out.print("{s}\n", .{L.tostring(-1).?}),
-        else => try out.writeAll("Unknown Zune version\n"),
+        else => try out.writeAll("unknown zune version\n"),
     }
     L.pop(1);
 

--- a/src/core/utils/print.zig
+++ b/src/core/utils/print.zig
@@ -81,7 +81,7 @@ fn ColorFormat(comptime fmt: []const u8, comptime use_colors: bool) []const u8 {
             }
             if (start >= 0) {
                 const color_name = fmt[start + 1 .. i];
-                const code = ColorMap.get(color_name) orelse @compileError("Unknown color: " ++ color_name);
+                const code = ColorMap.get(color_name) orelse @compileError("unknown color: " ++ color_name);
                 if (use_colors)
                     new_fmt = new_fmt ++ code;
                 start = -1;


### PR DESCRIPTION
A dedicated option for the zune debugger to send debug data to over localhost TCP. This makes it easier to implement for the debug adapters, and a stable way to control the debugger without app interference.

- Adds `--ipc-port` flag for debug command.
- Fixes setup command outputting incorrectly formatted paths on windows.